### PR TITLE
feat: NL Signal Intake (#52), Session Wiring (#56), and FedRAMP Security Documentation

### DIFF
--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -254,7 +254,7 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("create root agent: %w", err)
 	}
-	sessionSvc := session.NewSessionServiceDecorator(adksession.InMemoryService())
+	sessionSvc := session.NewServiceDecorator(adksession.InMemoryService())
 
 	a2aHandler, err := launcher.NewA2AHandler(launcher.A2AConfig{
 		Agent:          rootAgent,

--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -50,6 +50,7 @@ import (
 	"github.com/jordigilh/kubernaut-apifrontend/internal/ratelimit"
 	"github.com/jordigilh/kubernaut-apifrontend/internal/requestid"
 	"github.com/jordigilh/kubernaut-apifrontend/internal/resilience"
+	"github.com/jordigilh/kubernaut-apifrontend/internal/session"
 	"github.com/jordigilh/kubernaut-apifrontend/internal/streaming"
 )
 
@@ -222,29 +223,38 @@ func run() error {
 	})
 
 	// --- K8s dynamic client with circuit breaker ---
-	k8sClient, err := buildK8sDynamicClient(k8sCB, logger)
+	k8sClient, restCfg, err := buildK8sDynamicClient(k8sCB, logger)
 	if err != nil {
 		return fmt.Errorf("create K8s dynamic client: %w", err)
 	}
 
+	// Impersonating factory for triage tools (SEC-05): reads run as the authenticated user
+	var triageFactory auth.DynamicClientFactory
+	if restCfg != nil {
+		triageFactory = auth.NewImpersonatingDynamicFactory(restCfg)
+	}
+
 	agentCfg := agentpkg.AgentConfig{
-		GCPProject:    cfg.Agent.GCPProject,
-		GCPRegion:     cfg.Agent.GCPRegion,
-		Instruction:   "You are the Kubernaut API Frontend agent. Help users triage and remediate Kubernetes incidents.",
-		KABaseURL:     cfg.Agent.KABaseURL,
-		KAMCPEndpoint: cfg.Agent.KAMCPEndpoint,
-		DSBaseURL:     cfg.Agent.DSBaseURL,
-		K8sClient:     k8sClient,
-		DSClient:      dsClient,
-		KAClient:      kaClient,
-		Auditor:       auditor,
-		MCPClient:     mcpClient,
+		GCPProject:                 cfg.Agent.GCPProject,
+		GCPRegion:                  cfg.Agent.GCPRegion,
+		Instruction:                "You are the Kubernaut API Frontend agent. Help users triage and remediate Kubernetes incidents.",
+		KABaseURL:                  cfg.Agent.KABaseURL,
+		KAMCPEndpoint:              cfg.Agent.KAMCPEndpoint,
+		DSBaseURL:                  cfg.Agent.DSBaseURL,
+		K8sClient:                  k8sClient,
+		DSClient:                   dsClient,
+		KAClient:                   kaClient,
+		Auditor:                    auditor,
+		MCPClient:                  mcpClient,
+		ToolCallsTotal:             metricsReg.ToolCallsTotal,
+		ToolCallDuration:           metricsReg.ToolCallDuration,
+		ImpersonatingClientFactory: triageFactory,
 	}
 	rootAgent, _, err := agentpkg.NewRootAgent(agentCfg)
 	if err != nil {
 		return fmt.Errorf("create root agent: %w", err)
 	}
-	sessionSvc := adksession.InMemoryService()
+	sessionSvc := session.NewSessionServiceDecorator(adksession.InMemoryService())
 
 	a2aHandler, err := launcher.NewA2AHandler(launcher.A2AConfig{
 		Agent:          rootAgent,
@@ -475,17 +485,17 @@ func parseLogLevel(s string) (zapcore.Level, error) {
 	return l, err
 }
 
-func buildK8sDynamicClient(cb *resilience.K8sCircuitBreaker, logger logr.Logger) (dynamic.Interface, error) {
+func buildK8sDynamicClient(cb *resilience.K8sCircuitBreaker, logger logr.Logger) (dynamic.Interface, *rest.Config, error) {
 	restCfg, err := rest.InClusterConfig()
 	if err != nil {
 		logger.Error(err, "in-cluster config unavailable — CRD tools will return errors until cluster access is configured")
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	rawClient, err := dynamic.NewForConfig(restCfg)
 	if err != nil {
-		return nil, fmt.Errorf("create dynamic client: %w", err)
+		return nil, nil, fmt.Errorf("create dynamic client: %w", err)
 	}
 
-	return resilience.NewResilientDynamicClient(rawClient, cb), nil
+	return resilience.NewResilientDynamicClient(rawClient, cb), restCfg, nil
 }

--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -228,10 +228,14 @@ func run() error {
 		return fmt.Errorf("create K8s dynamic client: %w", err)
 	}
 
-	// Impersonating factory for triage tools (SEC-05): reads run as the authenticated user
+	// Impersonating factory for triage tools (SEC-05): reads run as the authenticated user.
+	// Wraps each impersonated client with the shared K8s circuit breaker (SEC-1 review).
 	var triageFactory auth.DynamicClientFactory
 	if restCfg != nil {
-		triageFactory = auth.NewImpersonatingDynamicFactory(restCfg)
+		cbWrapper := auth.ClientWrapper(func(c dynamic.Interface) dynamic.Interface {
+			return resilience.NewResilientDynamicClient(c, k8sCB)
+		})
+		triageFactory = auth.NewImpersonatingDynamicFactory(restCfg, cbWrapper)
 	}
 
 	agentCfg := agentpkg.AgentConfig{

--- a/deploy/helm/templates/clusterrole.yaml
+++ b/deploy/helm/templates/clusterrole.yaml
@@ -7,19 +7,29 @@ metadata:
     {{- include "kubernaut-apifrontend.labels" . | nindent 4 }}
 rules:
   # CRD read/write for core kubernaut resources
-  - apiGroups: ["kubernaut.io"]
+  - apiGroups: ["kubernaut.ai"]
     resources:
       - remediationrequests
-      - remediationactionrequests
-      - signalpipelines
+      - remediationapprovalrequests
+      - signalprocessings
       - investigationsessions
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["kubernaut.io"]
+  - apiGroups: ["kubernaut.ai"]
     resources:
       - remediationrequests/status
-      - remediationactionrequests/status
+      - remediationapprovalrequests/status
       - investigationsessions/status
     verbs: ["get", "update", "patch"]
+  # Core API read access for triage tools (events, pods, workloads)
+  - apiGroups: [""]
+    resources: ["events", "pods", "replicationcontrollers"]
+    verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list"]
   # TokenReview for JWT validation fallback
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]

--- a/docs/design/TOOL_EXECUTION_MODEL.md
+++ b/docs/design/TOOL_EXECUTION_MODEL.md
@@ -1,0 +1,244 @@
+# Tool Execution Model
+
+**Service:** kubernaut-apifrontend
+**NIST Controls:** AU-12 (Audit Record Generation), AC-3 (Access Enforcement), SI-10 (Information Input Validation)
+**Source of truth:** `internal/agent/root.go`, `internal/auth/dynamic_impersonation.go`, `internal/tools/helpers.go`, `internal/validate/k8s.go`
+**Last updated:** 2026-05-08
+
+---
+
+## 1. Request Lifecycle
+
+Every tool call traverses a deterministic pipeline from protocol ingress to Kubernetes API call and back.
+
+```mermaid
+sequenceDiagram
+    participant C as Client (A2A/MCP)
+    participant MW as Auth Middleware
+    participant L as Launcher (BeforeExecuteCallback)
+    participant SD as SessionServiceDecorator
+    participant ADK as ADK Executor
+    participant BC as BeforeToolCallbacks
+    participant T as Tool Handler
+    participant AC as AfterToolCallbacks
+    participant K8s as Kubernetes API
+
+    C->>MW: A2A JSON-RPC / MCP HTTP
+    MW->>MW: JWT validation → UserIdentity in context
+    MW->>L: Authenticated request
+    L->>L: Inject SessionCreateContext
+    L->>L: Emit audit.a2a_task.started
+    L->>SD: runner.Run(ctx, agent, session)
+    SD->>SD: Enrich session with CreateConfig (user, groups)
+    SD->>ADK: Delegate to wrapped session.Service
+    ADK->>BC: [RBAC Guard, Metrics Start]
+    BC->>T: Tool.Execute(ctx, args)
+    T->>K8s: API call (impersonated or SA-scoped)
+    K8s-->>T: Response
+    T-->>AC: Result or error
+    AC->>AC: [Metrics End, Audit Emit]
+    AC-->>ADK: Final result
+    ADK-->>C: Tool output in A2A/MCP response
+```
+
+---
+
+## 2. Callback Chain Ordering
+
+The ADK agent is configured with explicit callback ordering that provides a security-observability sandwich around every tool execution.
+
+### Before Tool Callbacks (ordered)
+
+| Position | Callback | Purpose | Failure Behavior |
+|----------|----------|---------|-----------------|
+| 1 | **RBAC Guard** | Checks `UserIdentity.Groups` against `rbac_roles.yaml` | Returns `{"error": "forbidden: ..."}` + emits `rbac.denied` audit event |
+| 2 | **Metrics Start** | Records `time.Now()` in `sync.Map` keyed by `FunctionCallID` | No-op on nil metrics (graceful degradation) |
+
+### After Tool Callbacks (ordered)
+
+| Position | Callback | Purpose | Failure Behavior |
+|----------|----------|---------|-----------------|
+| 1 | **Metrics End** | Computes duration, increments `af_tool_calls_total{tool,result}`, observes `af_tool_call_duration_seconds{tool,type}` | No-op on nil metrics |
+| 2 | **Audit Emit** | Emits `tool.invoked` event with tool name, result status, user ID, namespace | No-op on nil auditor (never blocks tool result) |
+
+### Invariants
+
+- Callbacks never mutate the tool result (return `nil, nil` to pass through)
+- Callbacks never block: audit emission is buffered and async
+- RBAC guard is fail-closed: missing identity or unknown role → reject
+- Metrics callbacks are fail-open: nil counters → skip silently
+
+---
+
+## 3. Client Resolution Model
+
+Tools access the Kubernetes API through two distinct client scopes, determined at construction time:
+
+```
+┌─────────────────────────────────────────────────────┐
+│                 Tool Registration                     │
+├─────────────────────────────────────────────────────┤
+│                                                     │
+│  ┌───────────────────────┐  ┌─────────────────────┐│
+│  │ Triage Tools (read)   │  │ CRD Tools (write)   ││
+│  │ af_list_events        │  │ kubernaut_*          ││
+│  │ af_get_pods           │  │ af_check_existing_rr ││
+│  │ af_get_workloads      │  │ af_create_rr         ││
+│  │ af_resolve_owner      │  │                      ││
+│  └──────────┬────────────┘  └──────────┬───────────┘│
+│             │                           │            │
+│             ▼                           ▼            │
+│  DynamicClientFactory         Static dynamic.Interface│
+│  (per-request impersonation)  (AF ServiceAccount)    │
+└─────────────────────────────────────────────────────┘
+```
+
+### DynamicClientFactory (Impersonated)
+
+```go
+type DynamicClientFactory func(ctx context.Context) (dynamic.Interface, error)
+```
+
+- Called at tool execution time (not at construction)
+- Extracts `UserIdentity` from context
+- Creates a `rest.Config` with `Impersonation{UserName, Groups}`
+- Returns a fresh `dynamic.Interface` scoped to the calling user's RBAC
+- **Fail-closed:** Returns error if no identity present
+- **Never cached:** A new client per request prevents identity leakage
+
+### Static Client (ServiceAccount)
+
+- Created once at startup from in-cluster config
+- Wrapped in `resilience.ResilientDynamicClient` (circuit breaker protection)
+- Used for AF-owned CRD operations where the AF is the resource owner
+- User identity is recorded in CRD labels/spec (not via impersonation)
+
+### Fallback Behavior
+
+If no `ImpersonatingClientFactory` is provided (e.g., running outside a cluster), triage tools fall back to `StaticDynamicFactory(k8sClient)` — the SA client is used for all operations.
+
+---
+
+## 4. Input Validation Contract
+
+Every tool validates inputs before making K8s API calls. Validation is centralized in the `internal/validate` package.
+
+### Validation Functions
+
+| Function | Validates | Standard | Error Wrapping |
+|----------|-----------|----------|----------------|
+| `validate.Namespace(ns)` | RFC 1123 DNS label (≤63 chars, lowercase alphanumeric + hyphens) | K8s namespace rules | `ErrInvalidInput` |
+| `validate.ResourceName(name)` | RFC 1123 DNS subdomain (≤253 chars) | K8s resource name rules | `ErrInvalidInput` |
+| `validate.LabelValue(v)` | K8s label value constraints (≤63 chars, optional) | K8s label spec | `ErrInvalidInput` |
+
+### Per-Tool Validation
+
+| Tool | Validated Fields | Additional Checks |
+|------|-----------------|-------------------|
+| af_list_events | namespace | — |
+| af_get_pods | namespace | label_selector format |
+| af_get_workloads | namespace | — |
+| af_resolve_owner | namespace, pod_name | — |
+| af_check_existing_rr | namespace, kind, name | — |
+| af_create_rr | namespace, kind, name | Description truncated at 2048 chars |
+| kubernaut_submit_signal | namespace/name via ParseRRID | — |
+| kubernaut_approve | namespace/name via ParseRRID | — |
+
+### Error Wrapping Pattern
+
+```go
+if err := validate.Namespace(args.Namespace); err != nil {
+    return Result{}, fmt.Errorf("%w: %v", ErrInvalidInput, err)
+}
+```
+
+The `ErrInvalidInput` sentinel allows callers to distinguish validation failures from runtime errors via `errors.Is`.
+
+---
+
+## 5. Output Safety
+
+Tool outputs are bounded to prevent excessive data from reaching the LLM context or etcd (via session storage).
+
+### TrimSliceToFit Generic
+
+```go
+func TrimSliceToFit[T any](items []T) ([]T, bool)
+```
+
+- Maximum output size: **4096 bytes** (JSON serialized)
+- Removes trailing elements until the serialization fits
+- Returns `(trimmedSlice, wasTrimmed)` so tools can signal truncation to the user
+- Matches the session `TrimToolResult` threshold for etcd safety
+
+### Tools Using TrimSliceToFit
+
+| Tool | Output Type | Truncation Signal |
+|------|------------|-------------------|
+| af_list_events | `[]EventSummary` | `"truncated": true` in result |
+| af_get_pods | `[]PodSummary` | `"truncated": true` in result |
+| af_get_workloads | `[]WorkloadSummary` | `"truncated": true` in result |
+
+### Error Translation
+
+`ToUserFriendlyError` translates Kubernetes API errors into safe, user-facing messages:
+
+| K8s Status Code | User-Facing Message | Purpose |
+|----------------|--------------------|---------| 
+| 403 Forbidden | "you lack access to ... — contact your cluster administrator" | Strips internal field paths |
+| 404 Not Found | "the requested resource does not exist" | Hides namespace/resource details |
+| 409 Conflict | "operation conflict — the resource was modified concurrently, please retry" | Actionable guidance |
+| Other | "operation failed (code N) — contact your cluster administrator" | Safe generic fallback |
+
+---
+
+## 6. Deduplication (singleflight)
+
+The `af_create_rr` tool uses `golang.org/x/sync/singleflight` to prevent duplicate RemediationRequest creation from concurrent LLM tool calls.
+
+### Fingerprint Calculation
+
+```go
+fingerprint = SHA256(namespace + "/" + kind + "/" + name)[:16]  // hex-encoded
+```
+
+### Deduplication Flow
+
+```
+af_create_rr(ns, kind, name)
+    │
+    ▼
+rrFingerprint(ns, kind, name) → key
+    │
+    ▼
+singleflight.Group.Do(key, func() {
+    1. HandleCheckExistingRR → check for non-terminal RR
+    2. If exists → return AlreadyExists result
+    3. If not → Create RR via K8s API
+})
+    │
+    ▼
+Result (shared if concurrent calls had same fingerprint)
+```
+
+### Safety Net
+
+Even without singleflight, `HandleCheckExistingRR` acts as an idempotency guard — it queries for non-terminal RRs with matching labels before creation. The singleflight eliminates redundant K8s API calls during the same execution window.
+
+---
+
+## 7. Error Sentinel Types
+
+| Sentinel | Package | Meaning | Typical Trigger |
+|----------|---------|---------|-----------------|
+| `ErrNotFound` | tools | Resource does not exist | K8s 404 |
+| `ErrForbidden` | tools | User lacks RBAC permission | K8s 403 (via impersonation) |
+| `ErrAlreadyTerminal` | tools | RR is in Completed/Failed/Cancelled state | Approve/Cancel on finished RR |
+| `ErrK8sUnavailable` | tools | No K8s client configured | nil client at startup |
+| `ErrInvalidInput` | tools | Input validation failure | Bad namespace, empty required field |
+
+All sentinels support `errors.Is` for programmatic handling in tests and upstream callers.
+
+---
+
+*Source files: `internal/agent/root.go`, `internal/auth/dynamic_impersonation.go`, `internal/tools/helpers.go`, `internal/tools/af_create_rr.go`, `internal/validate/k8s.go`, `internal/launcher/launcher.go`, `internal/session/decorator.go`*

--- a/docs/security/AUDIT_EVENT_CATALOG.md
+++ b/docs/security/AUDIT_EVENT_CATALOG.md
@@ -1,0 +1,116 @@
+# Audit Event Catalog
+
+Authoritative reference for all structured audit events emitted by the kubernaut-apifrontend service.
+
+**Source of truth:** `internal/audit/audit.go` (EventType constants)
+**Schema:** All events conform to the `audit.Event` struct:
+
+```go
+type Event struct {
+    Timestamp time.Time         `json:"timestamp"`
+    Type      EventType         `json:"type"`
+    RequestID string            `json:"request_id,omitempty"`
+    UserID    string            `json:"user_id,omitempty"`
+    SourceIP  string            `json:"source_ip,omitempty"`
+    Detail    map[string]string `json:"detail,omitempty"`
+}
+```
+
+---
+
+## Authentication & Authorization
+
+| Event Type | Constant | NIST Control | Trigger | Detail Fields |
+|-----------|----------|-------------|---------|---------------|
+| `auth.success` | `EventAuthSuccess` | AU-2, AC-7 | JWT validated or TokenReview accepted | `issuer`, `groups` |
+| `auth.failure` | `EventAuthFailure` | AU-2, AC-7 | JWT rejected or TokenReview denied | `reason` |
+| `rbac.denied` | `EventRBACDenied` | AC-3, AC-6 | Tool call blocked by RBAC guard | `tool`, `role`, `reason` |
+| `impersonation.created` | `EventImpersonation` | AC-3, AU-12 | K8s impersonated client created for user | `target_user`, `groups` |
+| `jwt.delegation` | `EventJWTDelegation` | AC-3, AU-12 | Original JWT forwarded to downstream service (KA) | `target_service` |
+
+**Emitted from:** `internal/auth/middleware.go`, `internal/agent/root.go` (RBAC guard)
+
+---
+
+## Tool Invocation
+
+| Event Type | Constant | NIST Control | Trigger | Detail Fields |
+|-----------|----------|-------------|---------|---------------|
+| `tool.invoked` | `EventToolInvoked` | AU-12, AU-2 | Any ADK tool call completes (success or error) | `tool`, `result` (`success`/`error`), `namespace` (if applicable), `error` (on failure) |
+| `mcp.tool_invoked` | `EventMCPToolInvoked` | AU-12 | MCP protocol tool/call request handled | `tool`, `session_id` |
+
+**Emitted from:** `internal/agent/root.go` (afterAudit callback), `internal/handler/mcp.go`
+
+---
+
+## Session Lifecycle
+
+| Event Type | Constant | NIST Control | Trigger | Detail Fields |
+|-----------|----------|-------------|---------|---------------|
+| `session.created` | `EventSessionCreated` | AU-2, SC-4 | InvestigationSession CRD created | `session_id`, `user`, `rr_ref` |
+| `session.deleted` | `EventSessionDeleted` | AU-2 | Session CRD deleted (user or TTL) | `session_id`, `reason` |
+| `session.phase_changed` | `EventSessionPhaseChanged` | AU-2 | Session transitions state (e.g. active → completed) | `session_id`, `from`, `to` |
+| `session.auto_cancelled` | `EventSessionAutoCancelled` | AU-2 | Session cancelled due to inactivity timeout | `session_id`, `idle_duration` |
+| `session.retention_deleted` | `EventSessionRetentionDeleted` | AU-2, SC-28 | Session deleted by retention policy (TTL controller) | `session_id`, `age` |
+
+**Emitted from:** `internal/session/service.go`, `internal/controller/ttl.go`
+
+---
+
+## A2A Protocol
+
+| Event Type | Constant | NIST Control | Trigger | Detail Fields |
+|-----------|----------|-------------|---------|---------------|
+| `a2a.task_started` | `EventA2ATaskStarted` | AU-2 | A2A `message/send` begins execution | `task_id`, `user` |
+| `a2a.task_completed` | `EventA2ATaskCompleted` | AU-2 | A2A task finishes successfully | `task_id`, `duration_ms` |
+| `a2a.task_failed` | `EventA2ATaskFailed` | AU-2 | A2A task fails with error | `task_id`, `error` |
+
+**Emitted from:** `internal/launcher/launcher.go` (BeforeExecute/AfterExecute callbacks)
+
+---
+
+## Infrastructure & Resilience
+
+| Event Type | Constant | NIST Control | Trigger | Detail Fields |
+|-----------|----------|-------------|---------|---------------|
+| `ratelimit.denied` | `EventRateLimitDenied` | SC-5 | Request rejected by rate limiter | `client_ip`, `limit`, `window` |
+| `circuitbreaker.trip` | `EventCircuitBreakerTrip` | SI-17 | Circuit breaker opens (dependency unhealthy) | `dependency`, `failures` |
+
+**Emitted from:** `internal/ratelimit/ratelimit.go`, (circuit breaker state change)
+
+---
+
+## Configuration
+
+| Event Type | Constant | NIST Control | Trigger | Detail Fields |
+|-----------|----------|-------------|---------|---------------|
+| `config.reloaded` | `EventConfigReloaded` | CM-3 | Hot-reload applied new configuration successfully | `source`, `keys_changed` |
+| `config.rejected` | `EventConfigRejected` | CM-3 | Hot-reload rejected invalid configuration | `source`, `reason` |
+
+**Emitted from:** `internal/config/hotreload.go`
+
+---
+
+## Backend & Delivery
+
+Events are delivered through the `audit.Emitter` interface. Two implementations exist:
+
+| Implementation | Package | Behavior |
+|---------------|---------|----------|
+| `LogEmitter` | `internal/audit` | Writes structured log entries via `logr` (stdout/stderr) |
+| `BufferedEmitter` | `internal/audit` | Batches events and flushes to `audit.Writer` (Data Store API) with overflow protection |
+
+**Buffering contract (ADR-019):** The `BufferedEmitter` holds up to `MaxPending` events in memory. If the buffer overflows, oldest events are dropped and `af_audit_buffer_overflow_total` metric increments. On graceful shutdown, `Close()` flushes remaining events with a context deadline.
+
+---
+
+## Adding New Events
+
+1. Define the `EventType` constant in `internal/audit/audit.go`
+2. Add the emit call at the appropriate location with `Detail` fields
+3. Update this catalog with the new event's trigger, fields, and NIST mapping
+4. Ensure tests verify emission (check `Emit` call count or captured events)
+
+---
+
+*Last updated: 2026-05-08 | Covers v1.5 milestone (issues #52, #56)*

--- a/docs/security/AUTHENTICATION_AND_RBAC.md
+++ b/docs/security/AUTHENTICATION_AND_RBAC.md
@@ -1,0 +1,197 @@
+# Authentication and RBAC Model
+
+**Service:** kubernaut-apifrontend
+**NIST Controls:** AC-2, AC-3, AC-6, IA-2, IA-5, IA-8
+**Source of truth:** `internal/auth/`, `internal/agent/rbac_roles.yaml`
+**Last updated:** 2026-05-08
+
+---
+
+## 1. Authentication Flow
+
+Every request to the API Frontend must carry a valid Bearer token. The authentication pipeline validates the token through a multi-stage process.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant MW as Auth Middleware
+    participant JV as JWTValidator
+    participant JWKS as JWKS Cache
+    participant TR as TokenReview API
+    participant CTX as Request Context
+
+    C->>MW: Request + Authorization: Bearer <token>
+    MW->>MW: Validate header (size, chars, scheme)
+    MW->>JV: Validate(ctx, token)
+
+    alt Token has known OIDC issuer
+        JV->>JWKS: Fetch signing keys (cached, CB-protected)
+        JWKS-->>JV: JWK Set
+        JV->>JV: Verify signature + exp + aud
+        JV->>JV: Execute CEL validation rules
+        JV-->>MW: UserIdentity
+    else Unknown issuer (ServiceAccount token)
+        JV->>TR: TokenReview.Create(token)
+        TR-->>JV: {authenticated, username, groups}
+        JV-->>MW: UserIdentity
+    end
+
+    MW->>CTX: WithUserIdentity(identity)
+    MW->>MW: Emit auth.success audit event
+    MW->>C: Continue to handler
+```
+
+### Validation Stages
+
+| Stage | Code Location | Failure Mode |
+|-------|--------------|--------------|
+| Body size enforcement | `middleware.go` L45 | 413 if > 1MB |
+| Header sanitization | `security.ValidateHeaderValue` | 400 if control chars |
+| Bearer scheme check | `middleware.go` L71-78 | 401 if non-Bearer |
+| OIDC signature verification | `jwt.go` JWTValidator.Validate | 401 if signature invalid |
+| Expiry validation | Claims.exp check | 401 `token_expired` |
+| Audience validation | Claims.aud vs configured audiences | 401 `invalid_audience` |
+| CEL rule evaluation | Compiled CEL programs per provider | 401 `cel_rule_failed` |
+| TokenReview fallback | `tokenreview.go` K8s API call | 401 if not authenticated |
+
+### JWKS Caching and Circuit Breaker
+
+The `JWKSCache` fetches provider signing keys with:
+- In-memory cache with TTL refresh
+- Circuit breaker to prevent cascading failures if the OIDC provider is down
+- Fail-open semantics: if cache has valid keys and circuit is open, validation continues with cached keys (see ADR-016)
+
+---
+
+## 2. RBAC Model
+
+After authentication, tool-level access control is enforced by a `BeforeToolCallback` registered in the ADK agent. The model is **fail-closed**: if no role match is found, the tool call is rejected and an `rbac.denied` audit event is emitted.
+
+### Role Assignment
+
+Roles are derived from the `groups` claim in the JWT token. The group-to-role mapping is defined externally (OIDC provider configuration). The AF maps roles to tool permissions.
+
+### Role Definitions
+
+| Role | Purpose | Tool Count |
+|------|---------|-----------|
+| `sre` | Full operational access — all tools | 20 |
+| `ai-orchestrator` | Automated agent — remediation + triage | 16 |
+| `observability` | Dashboard / monitoring integration — read + triage | 8 |
+| `l3-audit` | Forensic analysis — history, audit trail, effectiveness | 6 |
+| `cicd` | CI/CD pipeline integration — signal submission + status | 4 |
+| `remediation-approver` | Human approval gate — approve/reject only | 4 |
+
+### Tool Permission Matrix
+
+| Tool | sre | ai-orch | observ | l3-audit | cicd | approver |
+|------|-----|---------|--------|----------|------|----------|
+| kubernaut_list_remediations | Y | Y | Y | Y | Y | Y |
+| kubernaut_get_remediation | Y | Y | Y | Y | Y | Y |
+| kubernaut_submit_signal | Y | Y | | | Y | |
+| kubernaut_approve | Y | Y | | | | Y |
+| kubernaut_cancel_remediation | Y | Y | | | | |
+| kubernaut_watch | Y | Y | Y | | Y | Y |
+| kubernaut_start_investigation | Y | Y | | | | |
+| kubernaut_poll_investigation | Y | Y | | | | |
+| kubernaut_select_workflow | Y | Y | | | | |
+| present_decision | Y | Y | | | | |
+| kubernaut_list_workflows | Y | | Y | Y | | |
+| kubernaut_get_remediation_history | Y | | | Y | | |
+| kubernaut_get_effectiveness | Y | | Y | Y | | |
+| kubernaut_get_audit_trail | Y | | | Y | | |
+| af_list_events | Y | Y | Y | | | |
+| af_get_pods | Y | Y | Y | | | |
+| af_get_workloads | Y | Y | Y | | | |
+| af_resolve_owner | Y | Y | | | | |
+| af_check_existing_rr | Y | Y | | | | |
+| af_create_rr | Y | Y | | | | |
+
+### Enforcement Mechanism
+
+```
+BeforeToolCallback (RBAC Guard)
+  1. Extract UserIdentity from context
+  2. If nil → REJECT (fail-closed)
+  3. Map user groups to roles via GroupMapping
+  4. Check if any role grants the requested tool
+  5. If no match → REJECT + emit rbac.denied audit event
+  6. If match → ALLOW (proceed to tool execution)
+```
+
+---
+
+## 3. Kubernetes Impersonation Model
+
+The AF uses two distinct client scopes when making K8s API calls:
+
+| Scope | Client Type | Tools | Rationale |
+|-------|------------|-------|-----------|
+| User Impersonation | Per-request `dynamic.Interface` with impersonation headers | af_list_events, af_get_pods, af_get_workloads, af_resolve_owner | User only sees what their K8s RBAC permits (AC-6) |
+| Service Account | Static AF SA `dynamic.Interface` | All kubernaut_* tools, af_check_existing_rr, af_create_rr | AF manages its own CRDs; user does not need direct CRD access |
+
+### Impersonation Flow
+
+```mermaid
+sequenceDiagram
+    participant Tool as af_list_events
+    participant Factory as DynamicClientFactory
+    participant CTX as Context
+    participant K8s as K8s API Server
+
+    Tool->>Factory: factory(ctx)
+    Factory->>CTX: UserIdentityFromContext(ctx)
+    CTX-->>Factory: {username, groups}
+    Factory->>Factory: NewImpersonatedConfig(baseCfg, username, groups)
+    Factory->>Factory: dynamic.NewForConfig(impCfg)
+    Factory-->>Tool: impersonated dynamic.Interface
+    Tool->>K8s: List events (Impersonate-User: <username>)
+    K8s->>K8s: Evaluate user's RBAC (not AF SA's)
+    K8s-->>Tool: Events (or 403 Forbidden)
+```
+
+### Security Properties
+
+- The AF ServiceAccount requires the `impersonate` verb on `users` and `groups` resources (granted by ClusterRole)
+- A user cannot escalate beyond their own K8s RBAC, even if their AF role grants the tool
+- The impersonated config is created per-request and never cached (prevents identity leakage)
+
+---
+
+## 4. Kubernetes RBAC (ClusterRole)
+
+The Helm-managed ClusterRole grants the AF ServiceAccount:
+
+| API Group | Resources | Verbs | Purpose |
+|-----------|-----------|-------|---------|
+| `kubernaut.ai` | remediationrequests, remediationapprovalrequests, signalprocessings, investigationsessions | get, list, watch, create, update, patch, delete | CRD lifecycle management |
+| `kubernaut.ai` | */status | get, update, patch | Status subresource updates |
+| (core) | events, pods, replicationcontrollers | get, list | Triage tool reads (via impersonation) |
+| `apps` | deployments, statefulsets, replicasets, daemonsets | get, list | Workload triage |
+| `batch` | jobs, cronjobs | get, list | Job triage |
+| `authentication.k8s.io` | tokenreviews | create | JWT fallback validation |
+| `authorization.k8s.io` | subjectaccessreviews | create | Authorization checks |
+
+---
+
+## 5. Credential Lifecycle
+
+| Credential | Type | Rotation | Storage |
+|-----------|------|----------|---------|
+| OIDC signing keys | JWKS (RS256/ES256) | Auto-refreshed from provider `.well-known/jwks.json` | In-memory cache |
+| AF ServiceAccount token | K8s projected volume | Auto-rotated by kubelet (1h default) | tmpfs mount |
+| User JWT | OIDC token | Short-lived (provider-configured, typically 5-60min) | Not stored; validated per-request |
+
+---
+
+## 6. Related ADRs
+
+| ADR | Title | Relevance |
+|-----|-------|-----------|
+| ADR-013 | JWT Forwarding to KA | Original JWT forwarded byte-identical to downstream services |
+| ADR-016 | JWKS Fail-Open Rationale | When circuit breaker opens, cached keys allow validation to continue |
+| ADR-018 | Impersonation Risk Acceptance | Documents accepted risk of impersonation model |
+
+---
+
+*Source files: `internal/auth/middleware.go`, `internal/auth/jwt.go`, `internal/auth/tokenreview.go`, `internal/auth/impersonation.go`, `internal/auth/dynamic_impersonation.go`, `internal/agent/rbac_roles.yaml`, `deploy/helm/templates/clusterrole.yaml`*

--- a/docs/security/SECURITY_TESTING.md
+++ b/docs/security/SECURITY_TESTING.md
@@ -1,0 +1,193 @@
+# Security Testing Pipeline
+
+**Service:** kubernaut-apifrontend
+**NIST Controls:** SA-11 (Developer Testing and Evaluation), SI-2 (Flaw Remediation), RA-5 (Vulnerability Monitoring and Scanning)
+**Source of truth:** `Makefile`, `hack/validate-maturity.sh`, test suite, CI configuration
+**Last updated:** 2026-05-08
+
+---
+
+## 1. Testing Pyramid
+
+```
+                ┌─────────────────┐
+                │   Performance   │  k6 scripts (4 profiles)
+                │   (deferred)    │  docs/testing/PERFORMANCE_TEST_PLAN.md
+                └────────┬────────┘
+               ┌─────────┴─────────┐
+               │   Integration     │  -tags=integration, cross-package
+               │   (test-integration) │  E2E flows with fakes
+               └─────────┬─────────┘
+        ┌────────────────┴────────────────┐
+        │           Unit Tests            │  77 test files, Ginkgo + Gomega
+        │          (test-unit)            │  ~354 specs, per-package isolation
+        └─────────────────────────────────┘
+```
+
+### Test File Distribution
+
+| Package | Test Files | Coverage Focus |
+|---------|-----------|---------------|
+| `internal/tools/` | 22 | Tool behavior, input validation, K8s client mocking |
+| `internal/auth/` | 5 | JWT validation, RBAC, impersonation, delegation |
+| `internal/handler/` | 6 | HTTP routing, MCP conformance, agent card |
+| `internal/session/` | 6 | Session lifecycle, decorator, concurrency, state machine |
+| `internal/resilience/` | 4 | Circuit breaker, retry, K8s dynamic client |
+| `internal/launcher/` | 5 | A2A conformance, error handling, model mapping |
+| `internal/ka/` | 5 | KA REST client, MCP SDK client |
+| `internal/metrics/` | 2 | Prometheus registration, recording rules |
+| `internal/audit/` | 2 | Emitter, buffered emitter behavior |
+| `internal/config/` | 2 | Config parsing, hot-reload |
+| Others | 18 | httputil, logging, requestid, security, streaming, controller, ds |
+
+---
+
+## 2. Static Analysis
+
+All static analysis gates run before tests in the CI pipeline and block merge on failure.
+
+| Tool | Makefile Target | What It Catches |
+|------|----------------|-----------------|
+| `go vet` | `make vet` | Suspicious constructs, unreachable code, incorrect format strings |
+| `go fmt` | `make fmt` | Non-canonical formatting (enforces `gofmt` style) |
+| `golangci-lint` | `make lint` | 50+ linters including `errcheck`, `gocritic`, `gosec`, `staticcheck` |
+| Race detector | `--race` flag in `make test-unit` | Data races in concurrent code |
+| OpenAPI validation | `make validate-openapi` | Schema conformance via `vacuum lint` |
+| Helm lint | `make helm-lint` | Chart template errors, missing values |
+| Maturity validation | `make validate-maturity-ci` | Service maturity criteria (8 checks) |
+
+### Maturity Validation Checks (`hack/validate-maturity.sh`)
+
+| # | Check | What It Verifies |
+|---|-------|------------------|
+| 1 | Prometheus metrics namespace | All metrics use `af_` namespace |
+| 2 | Health endpoint `/healthz` | Liveness probe registered |
+| 3 | Readiness endpoint `/readyz` | Readiness probe registered |
+| 4 | Graceful shutdown | Signal handling present |
+| 5 | RFC 7807 errors | Problem responses implemented |
+| 6 | Audit trail | `audit.Emitter` / `audit.Event` usage |
+| 7 | Structured logging | slog or zap configured |
+| 8 | Circuit breaker | `gobreaker` in resilience package |
+
+---
+
+## 3. Dependency Scanning
+
+| Tool | Makefile Target | Output | Severity Gate |
+|------|----------------|--------|---------------|
+| **Trivy** | `make image-scan` | Console report | Exit code 1 on CRITICAL or HIGH CVEs |
+| **Syft** | `make sbom` | `sbom.cdx.json` (CycloneDX) | N/A (artifact generation) |
+| **Go module audit** | `go mod verify` | — | Fails on tampered checksums |
+
+### Trivy Configuration
+
+- Scans the container image (`quay.io/kubernaut/apifrontend:latest`)
+- Severity filter: `CRITICAL,HIGH` only
+- `.trivyignore` file for accepted risk suppressions (each entry requires justification comment)
+- Exit code 1 fails the CI pipeline
+
+### SBOM Generation
+
+- Format: CycloneDX JSON (`sbom.cdx.json`)
+- Generated from the final container image (includes all transitive deps)
+- Artifact published alongside release for supply chain consumers
+
+---
+
+## 4. Coverage Requirements
+
+Coverage is measured using Go's native coverage tooling via Ginkgo's `--coverprofile` flag.
+
+| Tier | Packages | Target | Rationale |
+|------|----------|--------|-----------|
+| Security-critical | `internal/auth/`, `internal/security/` | 85%+ | Authentication, sanitization, RBAC |
+| Session lifecycle | `internal/session/` | 90%+ | State machine correctness |
+| Tools | `internal/tools/` | 77%+ | Tool behavior under all input conditions |
+| Metrics | `internal/metrics/` | 100% | Registration correctness, no silent failures |
+| Resilience | `internal/resilience/` | 80%+ | Circuit breaker state transitions |
+
+### Coverage Packages (from Makefile `COVERPKGS`)
+
+All `internal/` packages are included in coverage measurement:
+`auth`, `ratelimit`, `security`, `httputil`, `logging`, `requestid`, `audit`, `metrics`, `agent`, `tools`, `ka`, `ds`, `session`, `config`, `handler`, `launcher`, `resilience`, `streaming`, `controller`
+
+---
+
+## 5. CI Enforcement Gates
+
+The following gates must pass before a PR can be merged:
+
+| Gate | Command | Blocks Merge |
+|------|---------|-------------|
+| Format check | `go fmt ./...` (diff check) | Yes |
+| Vet | `go vet ./...` | Yes |
+| Lint | `golangci-lint run ./...` | Yes |
+| Unit tests + race detector | `ginkgo -v --race --coverpkg=... ./internal/...` | Yes |
+| Maturity validation | `bash hack/validate-maturity.sh` | Yes |
+| Image vulnerability scan | `trivy image --severity CRITICAL,HIGH --exit-code 1` | Yes |
+| OpenAPI schema validation | `vacuum lint api/openapi/apifrontend-v1.yaml` | Yes |
+| Helm chart lint | `helm lint deploy/helm/` | Yes |
+| Coverage threshold | Enforced per-tier (see above) | Advisory (warning) |
+
+### Test Execution Flags
+
+```bash
+ginkgo -v \
+  --race \
+  --coverpkg=./internal/auth/...,./internal/tools/...,... \
+  --coverprofile=cover.out \
+  ./internal/...
+```
+
+Key flags:
+- `--race`: Enables Go's race detector for all test executions
+- `--coverpkg`: Explicit package list ensures cross-package coverage is captured
+- `-v`: Verbose output for CI log traceability
+
+---
+
+## 6. Performance Testing
+
+Performance tests are defined but execution is deferred until proper hardware is available.
+
+| Script | Profile | SLO Validated |
+|--------|---------|---------------|
+| `health-baseline.js` | Baseline (10 users, 5m) | Idle resource usage |
+| `mcp-tools-call.js` | Normal/Peak | Tool call latency p95 < 500ms |
+| `sse-streams.js` | Normal/Peak | SSE connection handling |
+| `mixed-workload.js` | Peak/Stress | Combined load behavior |
+
+Dry-run validation: `make test-perf-local` (validates scripts parse correctly)
+
+See `docs/testing/PERFORMANCE_TEST_PLAN.md` for full profile definitions and SLO mappings.
+
+---
+
+## 7. Known Gaps and Roadmap
+
+| Gap | Status | Timeline | Mitigation |
+|-----|--------|----------|------------|
+| DAST (Dynamic Application Security Testing) | Not yet applicable | Post-v1.5 | Compensated by comprehensive unit/integration tests + race detector |
+| Penetration testing | Not yet applicable | Post-GA | External audit planned for GA milestone |
+| Fuzzing (`go test -fuzz`) | Backlog | v1.6 | Input validation via `internal/validate` package provides defense-in-depth |
+| Dependency license scanning | Not automated | v1.6 | Manual review during dependency updates |
+| Signed container images (cosign) | Backlog | Pre-GA | SBOM generation is already in place |
+
+---
+
+## 8. Security-Specific Test Categories
+
+| Category | Example Tests | Validates |
+|----------|--------------|-----------|
+| Auth bypass attempts | `jwt_test.go` — expired, malformed, wrong audience | IA-2, IA-8 |
+| RBAC enforcement | `rbac_tools_test.go` — role/tool matrix | AC-3, AC-6 |
+| Input validation | `af_*_test.go` — invalid namespaces, SQL injection | SI-10 |
+| Rate limit behavior | `ratelimit_test.go` — burst, eviction | SC-5 |
+| Circuit breaker state | `k8s_cb_test.go`, `integration_test.go` | SC-7 (availability) |
+| Audit event emission | `audit_test.go`, `buffered_test.go` | AU-2, AU-12 |
+| Header sanitization | `sanitize_test.go` — control chars, injection | SI-10 |
+| Impersonation isolation | `impersonation_test.go` — no identity leakage | AC-6 |
+
+---
+
+*Source files: `Makefile`, `hack/validate-maturity.sh`, `docs/testing/PERFORMANCE_TEST_PLAN.md`, 77 `*_test.go` files across `internal/`*

--- a/docs/security/SERVICE_BOUNDARY.md
+++ b/docs/security/SERVICE_BOUNDARY.md
@@ -1,0 +1,260 @@
+# Service Boundary Definition
+
+**Service:** kubernaut-apifrontend
+**NIST Controls:** SC-7 (Boundary Protection), SC-8 (Transmission Confidentiality), SC-13 (Cryptographic Protection), AC-4 (Information Flow Enforcement)
+**Source of truth:** `cmd/apifrontend/main.go`, `deploy/helm/`, `internal/ratelimit/`, `internal/resilience/`
+**Last updated:** 2026-05-08
+
+---
+
+## 1. Trust Boundary Diagram
+
+```mermaid
+graph TB
+    subgraph untrusted [Untrusted Zone — External Clients]
+        RHDH[Red Hat Developer Hub]
+        Kagenti[kagenti]
+        Third[Third-Party A2A/MCP Clients]
+    end
+
+    subgraph boundary [Trust Boundary — AF Pod]
+        direction TB
+        RL_IP[IP Rate Limiter — Pre-Auth]
+        AuthMW[Auth Middleware — JWT/TokenReview]
+        RL_User[User Rate Limiter — Post-Auth]
+        Router[HTTP Router]
+        A2A[A2A Handler]
+        MCP[MCP Handler]
+        Agent[ADK Agent + Tool Dispatch]
+    end
+
+    subgraph trusted [Trusted Zone — Cluster Internal]
+        K8sAPI[Kubernetes API Server]
+        KA[Kubernaut Agent — REST/MCP]
+        DS[Data Store API]
+        LLM[Vertex AI — Claude Sonnet 4.6]
+    end
+
+    RHDH -->|HTTPS + Bearer JWT| RL_IP
+    Kagenti -->|HTTPS + Bearer JWT| RL_IP
+    Third -->|HTTPS + Bearer JWT| RL_IP
+
+    RL_IP --> AuthMW
+    AuthMW --> RL_User
+    RL_User --> Router
+    Router --> A2A
+    Router --> MCP
+    A2A --> Agent
+    MCP --> Agent
+
+    Agent -->|Impersonated — user scope| K8sAPI
+    Agent -->|SA — AF scope| K8sAPI
+    Agent -->|REST + JWT delegation| KA
+    Agent -->|Audit events via REST| DS
+    Agent -->|LLM inference| LLM
+```
+
+---
+
+## 2. Ingress Points
+
+All ingress enters through a single HTTP listener on the configured port (default 8080). There is no secondary listener or sidecar port.
+
+| Endpoint | Protocol | Auth Required | Purpose |
+|----------|----------|---------------|---------|
+| `POST /` | A2A JSON-RPC 2.0 | Yes (Bearer JWT) | Agent task execution |
+| `POST /mcp` | MCP Streamable HTTP | Yes (Bearer JWT) | MCP tool invocation |
+| `GET /mcp/sse` | Server-Sent Events | Yes (Bearer JWT) | Streaming MCP responses |
+| `GET /.well-known/agent.json` | HTTP GET | No | A2A Agent Card discovery |
+| `GET /healthz` | HTTP GET | No | Liveness probe (kubelet) |
+| `GET /readyz` | HTTP GET | No | Readiness probe (kubelet) |
+| `GET /metrics` | HTTP GET | No | Prometheus metrics scrape |
+
+### HTTP Server Hardening
+
+| Setting | Value | Rationale |
+|---------|-------|-----------|
+| ReadTimeout | 60s | Prevents slow-read attacks |
+| ReadHeaderTimeout | 10s | Limits header-only slow loris |
+| IdleTimeout | 120s | Reclaims idle keep-alive connections |
+| WriteTimeout | 0 (disabled) | Required for SSE/streaming; per-request deadlines via `SetWriteDeadline()` |
+| MaxBodySize | 1 MB (`http.MaxBytesReader`) | Prevents memory exhaustion on request body |
+
+---
+
+## 3. Egress Points
+
+| Destination | Protocol | Client Type | Auth Mechanism | Circuit Breaker |
+|-------------|----------|-------------|----------------|-----------------|
+| Kubernetes API Server | HTTPS (in-cluster TLS) | `dynamic.Interface` | ServiceAccount token (projected volume) | `k8s-api` CB |
+| Kubernaut Agent (KA) REST | HTTPS | Custom `ka.Client` | JWT delegation (original user token) | `ka` CB |
+| Kubernaut Agent (KA) MCP | HTTPS | `ka.SDKMCPClient` | JWT delegation (`ContextJWTDelegationTransport`) | — |
+| Data Store (DS) | HTTPS | ogen-generated client | ServiceAccount context | `ds-rest` CB |
+| Vertex AI (LLM) | HTTPS | ADK genai client | GCP Workload Identity | — |
+
+---
+
+## 4. Encryption in Transit
+
+| Connection | TLS Requirement | Certificate Source |
+|------------|----------------|-------------------|
+| Client → AF ingress | TLS 1.2+ (terminated at Ingress/Route) | Cluster cert manager or ACME |
+| AF → K8s API Server | mTLS (in-cluster) | SA projected token + cluster CA |
+| AF → KA REST | TLS 1.2+ | Cluster internal CA |
+| AF → DS REST | TLS 1.2+ | Cluster internal CA |
+| AF → Vertex AI | TLS 1.3 | Google public CA |
+
+**Note:** Pod-to-pod communication within the cluster relies on the network CNI's encryption capabilities (e.g., WireGuard in Cilium) or service mesh mTLS if deployed. The AF itself terminates TLS at the Ingress controller level; the pod listens on plain HTTP internally.
+
+---
+
+## 5. Rate Limiting and DoS Protection
+
+Rate limiting is applied as a layered defense at the service boundary:
+
+```
+Request → [IP Rate Limiter] → [Auth Middleware] → [User Rate Limiter] → Handler
+                 ↓ reject              ↓ reject            ↓ reject
+              429 + audit            401 + audit         429 + audit
+```
+
+### Pre-Authentication (IP-Based)
+
+| Parameter | Default | Hot-Reloadable |
+|-----------|---------|----------------|
+| Requests per second per IP | 10 | Yes |
+| Burst (token bucket capacity) | 20 | Yes |
+| Stale entry eviction interval | 5 min | No |
+| Maximum entry age | 10 min | No |
+
+### Post-Authentication (User-Based)
+
+| Parameter | Default | Hot-Reloadable |
+|-----------|---------|----------------|
+| Requests per minute per user | 30 | Yes |
+| Max concurrent sessions per user | 5 | No (requires restart) |
+| Tool calls per minute per user | 60 | Yes |
+
+### Denial Events
+
+Both rate limiter tiers emit structured audit events (`ratelimit.denied`) containing:
+- Source IP (pre-auth) or User ID (post-auth)
+- Limiter type (`ip` or `user`)
+- Current limit values
+
+---
+
+## 6. Resilience at the Boundary (Egress Protection)
+
+Each egress dependency is protected by a circuit breaker to prevent cascading failures:
+
+| Dependency | Library | Failure Threshold | Half-Open Window | Metrics |
+|-----------|---------|-------------------|-----------------|---------|
+| `k8s-api` | `sony/gobreaker/v2` | Configurable (default 5) | Configurable timeout | `circuit_breaker_state` gauge |
+| `ka` | `sony/gobreaker/v2` | Configurable | Configurable | `circuit_breaker_state` gauge |
+| `ds-rest` | `sony/gobreaker/v2` | Configurable | Configurable | `circuit_breaker_state` gauge |
+
+Additionally, the KA and DS clients use retry transports with exponential backoff:
+- Configurable max retries, initial backoff, max backoff
+- Only retries on configured HTTP status codes (e.g., 502, 503, 504)
+- Retry attempts tracked in `downstream_retry_total` counter
+
+---
+
+## 7. Network Policy Recommendations
+
+Cluster administrators should enforce the following `NetworkPolicy` constraints:
+
+```yaml
+# Allow ingress only from known sources (Ingress controller, monitoring)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kubernaut-apifrontend-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kubernaut-apifrontend
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+      ports:
+        - port: 8080
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-monitoring
+      ports:
+        - port: 8080
+          protocol: TCP
+---
+# Allow egress only to known destinations
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kubernaut-apifrontend-egress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kubernaut-apifrontend
+  policyTypes: [Egress]
+  egress:
+    # K8s API Server
+    - to:
+        - ipBlock:
+            cidr: <api-server-cidr>/32
+      ports:
+        - port: 6443
+          protocol: TCP
+    # KA service (same namespace or cross-namespace)
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: kubernaut-agent
+      ports:
+        - port: 8443
+          protocol: TCP
+    # DS service
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: kubernaut-datastorage
+      ports:
+        - port: 8443
+          protocol: TCP
+    # Vertex AI (external)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - port: 443
+          protocol: TCP
+    # DNS resolution
+    - to: []
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+```
+
+---
+
+## 8. Graceful Shutdown Sequence
+
+The AF implements an ordered shutdown to prevent data loss at the boundary:
+
+1. **Signal received** (SIGINT/SIGTERM)
+2. **Readiness probe fails** (`readyz` returns 503) — LB stops routing new traffic
+3. **SSE drain** — Active streaming connections receive close frames (5s timeout)
+4. **HTTP drain** — `srv.Shutdown()` waits for in-flight requests (30s timeout)
+5. **Audit flush** — Buffered audit events are flushed to DS (5s timeout)
+6. **Logger sync** — Final log messages flushed to stderr
+
+---
+
+*Source files: `cmd/apifrontend/main.go`, `internal/ratelimit/`, `internal/resilience/`, `deploy/helm/templates/`, `docs/design/ARCHITECTURE.md`*

--- a/docs/tests/52/test_plan.md
+++ b/docs/tests/52/test_plan.md
@@ -1,0 +1,211 @@
+# Test Plan: NL Signal Intake Tools (#52)
+
+**Test Plan Identifier:** TP-AF-052
+**Issue:** #52
+**Version:** 1.0
+**Date:** 2026-05-08
+**Status:** Draft
+
+---
+
+## 1. Introduction
+
+This test plan validates the six Kubernetes observability and remediation tools that enable natural-language-driven signal intake (ARCHITECTURE.md Section 5, Flow 1). These tools allow the agent to inspect cluster state, identify issues, and create remediation requests through conversational interaction.
+
+### 1.1 Scope
+
+- `af_list_events`: List K8s Events filtered by namespace (impersonated)
+- `af_get_pods`: Get pod status summaries with container states (impersonated)
+- `af_get_workloads`: Get Deployment/StatefulSet health (impersonated)
+- `af_resolve_owner`: Walk owner references to root workload (impersonated)
+- `af_check_existing_rr`: Check for duplicate RR by fingerprint (AF SA)
+- `af_create_rr`: Create RemediationRequest with singleflight dedup (AF SA)
+
+### 1.2 Out of Scope
+
+- Session management (covered by TP-AF-056)
+- Existing CRD tools (kubernaut_list_remediations, etc.) — already tested
+- Full E2E with real cluster (covered by PR-D E2E CI)
+- LLM model integration (PR5)
+
+### 1.3 References
+
+- ARCHITECTURE.md Section 5: Agent Flows (Flow 1 — NL Signal Intake)
+- ARCHITECTURE.md Section 7: Observability (af_tool_calls_total)
+- ADR-013: JWT Forwarding (impersonation for read tools)
+- FedRAMP Controls: SI-10 (input validation), AC-3 (access enforcement)
+- `k8s.io/apimachinery/pkg/util/validation` for RFC 1123 compliance
+
+---
+
+## 2. Test Items
+
+| Item | Package | File |
+|------|---------|------|
+| `HandleListEvents` | `internal/tools` | `af_list_events.go` |
+| `HandleGetPods` | `internal/tools` | `af_get_pods.go` |
+| `HandleGetWorkloads` | `internal/tools` | `af_get_workloads.go` |
+| `HandleResolveOwner` | `internal/tools` | `af_resolve_owner.go` |
+| `HandleCheckExistingRR` | `internal/tools` | `af_check_existing_rr.go` |
+| `HandleCreateRR` | `internal/tools` | `af_create_rr.go` |
+| `validate.Namespace` | `internal/validate` | `k8s.go` |
+| `validate.ResourceName` | `internal/validate` | `k8s.go` |
+
+---
+
+## 3. Business Acceptance Criteria
+
+| ID | Criterion | Source | Priority |
+|----|-----------|--------|----------|
+| BAC-52-001 | `af_list_events` returns K8s Events filtered by namespace | ARCH §5.1 | P0 |
+| BAC-52-002 | `af_get_pods` returns pod status summary with container states | ARCH §5.1 | P0 |
+| BAC-52-003 | `af_get_workloads` returns Deployment/SS health (replicas, conditions) | ARCH §5.1 | P0 |
+| BAC-52-004 | `af_resolve_owner` walks owner refs to root workload (max 10 hops) | ARCH §5.1 | P0 |
+| BAC-52-005 | `af_check_existing_rr` detects duplicate RR by namespace+kind+name | ARCH §5.2 | P0 |
+| BAC-52-006 | `af_create_rr` creates RR CRD with spec (targetRef, severity, description) | ARCH §5.2 | P0 |
+| BAC-52-007 | `af_create_rr` uses singleflight per fingerprint to prevent duplicates | ARCH §5.2 | P0 |
+| BAC-52-008 | Tool outputs are trimmed to max 4KB for model context safety | ARCH §7 | P1 |
+| BAC-52-009 | All namespace/name inputs validated as RFC 1123 before K8s API call | SI-10 | P0 |
+| BAC-52-010 | Nil K8s client returns ErrK8sUnavailable (circuit breaker open) | Resilience | P0 |
+
+---
+
+## 4. Test Cases
+
+### 4.1 af_list_events (8 tests)
+
+| ID | Description | BAC | Priority |
+|----|-------------|-----|----------|
+| UT-AF-052-001 | Happy path: returns events in namespace | BAC-52-001 | P0 |
+| UT-AF-052-002 | Empty namespace rejected with validation error | BAC-52-009 | P0 |
+| UT-AF-052-003 | Path traversal namespace (../../etc) rejected | BAC-52-009 | P0 |
+| UT-AF-052-004 | Namespace not found returns empty list (not error) | BAC-52-001 | P1 |
+| UT-AF-052-005 | Large result (100+ events) is trimmed to 4KB | BAC-52-008 | P1 |
+| UT-AF-052-006 | Nil client returns ErrK8sUnavailable | BAC-52-010 | P0 |
+| UT-AF-052-007 | Concurrent calls are safe under -race | Concurrency | P1 |
+| UT-AF-052-008 | Tool increments af_tool_calls_total metric | Observability | P0 |
+
+### 4.2 af_get_pods (8 tests)
+
+| ID | Description | BAC | Priority |
+|----|-------------|-----|----------|
+| UT-AF-052-010 | Happy path: returns pod summaries with container states | BAC-52-002 | P0 |
+| UT-AF-052-011 | Empty namespace rejected | BAC-52-009 | P0 |
+| UT-AF-052-012 | Unicode namespace rejected | BAC-52-009 | P0 |
+| UT-AF-052-013 | Max-length+1 namespace rejected | BAC-52-009 | P1 |
+| UT-AF-052-014 | Large result trimmed to 4KB | BAC-52-008 | P1 |
+| UT-AF-052-015 | Nil client returns ErrK8sUnavailable | BAC-52-010 | P0 |
+| UT-AF-052-016 | Concurrent calls safe | Concurrency | P1 |
+| UT-AF-052-017 | Filters by label selector when provided | BAC-52-002 | P1 |
+
+### 4.3 af_get_workloads (8 tests)
+
+| ID | Description | BAC | Priority |
+|----|-------------|-----|----------|
+| UT-AF-052-020 | Happy path: returns Deployments and StatefulSets | BAC-52-003 | P0 |
+| UT-AF-052-021 | Empty namespace rejected | BAC-52-009 | P0 |
+| UT-AF-052-022 | Specific workload name filters results | BAC-52-003 | P1 |
+| UT-AF-052-023 | Includes replica counts and conditions | BAC-52-003 | P0 |
+| UT-AF-052-024 | Large result trimmed | BAC-52-008 | P1 |
+| UT-AF-052-025 | Nil client returns ErrK8sUnavailable | BAC-52-010 | P0 |
+| UT-AF-052-026 | Concurrent calls safe | Concurrency | P1 |
+| UT-AF-052-027 | Path traversal in workload name rejected | BAC-52-009 | P0 |
+
+### 4.4 af_resolve_owner (10 tests)
+
+| ID | Description | BAC | Priority |
+|----|-------------|-----|----------|
+| UT-AF-052-030 | Happy path: Pod -> ReplicaSet -> Deployment | BAC-52-004 | P0 |
+| UT-AF-052-031 | Single hop: Pod with no owner returns Pod itself | BAC-52-004 | P0 |
+| UT-AF-052-032 | Max depth (10 hops) stops traversal | BAC-52-004 | P0 |
+| UT-AF-052-033 | Circular ownership detected and stopped | BAC-52-004 | P1 |
+| UT-AF-052-034 | Invalid namespace rejected | BAC-52-009 | P0 |
+| UT-AF-052-035 | Invalid resource name rejected | BAC-52-009 | P0 |
+| UT-AF-052-036 | Nil client returns ErrK8sUnavailable | BAC-52-010 | P0 |
+| UT-AF-052-037 | Owner reference to non-existent resource is handled | BAC-52-004 | P1 |
+| UT-AF-052-038 | Concurrent calls safe | Concurrency | P1 |
+| UT-AF-052-039 | Returns full chain in output | BAC-52-004 | P0 |
+
+### 4.5 af_check_existing_rr (8 tests)
+
+| ID | Description | BAC | Priority |
+|----|-------------|-----|----------|
+| UT-AF-052-040 | Happy path: finds existing RR by fingerprint labels | BAC-52-005 | P0 |
+| UT-AF-052-041 | No match returns exists=false | BAC-52-005 | P0 |
+| UT-AF-052-042 | Empty namespace rejected | BAC-52-009 | P0 |
+| UT-AF-052-043 | Empty kind rejected | BAC-52-009 | P0 |
+| UT-AF-052-044 | Empty name rejected | BAC-52-009 | P0 |
+| UT-AF-052-045 | Nil client returns ErrK8sUnavailable | BAC-52-010 | P0 |
+| UT-AF-052-046 | Concurrent calls safe | Concurrency | P1 |
+| UT-AF-052-047 | Terminal-phase RRs excluded from duplicate check | BAC-52-005 | P1 |
+
+### 4.6 af_create_rr (12 tests)
+
+| ID | Description | BAC | Priority |
+|----|-------------|-----|----------|
+| UT-AF-052-050 | Happy path: creates RR with correct spec | BAC-52-006 | P0 |
+| UT-AF-052-051 | Singleflight dedup: concurrent identical creates yield one RR | BAC-52-007 | P0 |
+| UT-AF-052-052 | Check-then-create: existing RR returns AlreadyExists | BAC-52-005 | P0 |
+| UT-AF-052-053 | Empty namespace rejected | BAC-52-009 | P0 |
+| UT-AF-052-054 | Empty kind rejected | BAC-52-009 | P0 |
+| UT-AF-052-055 | Empty name rejected | BAC-52-009 | P0 |
+| UT-AF-052-056 | Path traversal in description sanitized | BAC-52-009 | P1 |
+| UT-AF-052-057 | Nil client returns ErrK8sUnavailable | BAC-52-010 | P0 |
+| UT-AF-052-058 | RR spec includes severity field | BAC-52-006 | P0 |
+| UT-AF-052-059 | RR spec includes reportedBy from username | BAC-52-006 | P0 |
+| UT-AF-052-060 | Max-length+1 description truncated (not rejected) | BAC-52-008 | P1 |
+| UT-AF-052-061 | Concurrent different fingerprints create independent RRs | BAC-52-007 | P0 |
+
+---
+
+## 5. Pass/Fail Criteria
+
+- All 54 tests pass with `-race` flag
+- Coverage >= 80% per tool file
+- `golangci-lint run` reports 0 errors on new files
+- No `panic()` in production code paths
+- All validation errors include field name for SRE diagnosis
+- `go mod tidy` clean
+
+---
+
+## 6. Test Environment
+
+- Go 1.25.6
+- `k8s.io/client-go/dynamic/fake` for K8s API simulation
+- `golang.org/x/sync/singleflight` for deduplication
+- Ginkgo v2 + Gomega test framework (ADR-015)
+- `-race` flag mandatory for concurrency tests
+
+---
+
+## 7. Design Notes
+
+### 7.1 Client Split
+
+| Tool | Client | Rationale |
+|------|--------|-----------|
+| af_list_events | Impersonated | User-scoped RBAC enforcement |
+| af_get_pods | Impersonated | User-scoped RBAC enforcement |
+| af_get_workloads | Impersonated | User-scoped RBAC enforcement |
+| af_resolve_owner | Impersonated | User-scoped RBAC enforcement |
+| af_check_existing_rr | AF SA | CRD access not granted to end users |
+| af_create_rr | AF SA | CRD write requires privileged SA |
+
+### 7.2 Output Trimming
+
+All tool handlers trim output to 4KB max (consistent with `session.TrimToolResult` threshold) to prevent model context overflow. Trimming appends `"...(truncated)"` marker.
+
+### 7.3 Singleflight Dedup (af_create_rr)
+
+```
+fingerprint = sha256(namespace + "/" + kind + "/" + name)
+
+singleflight.Do(fingerprint, func() {
+    1. af_check_existing_rr (label query)
+    2. if exists -> return AlreadyExists
+    3. create RR
+})
+```
+
+Multi-replica safety: K8s API-level conflict + label check on retry catches cross-pod races.

--- a/docs/tests/56/test_plan_v2.md
+++ b/docs/tests/56/test_plan_v2.md
@@ -1,0 +1,152 @@
+# Test Plan: InvestigationSession Production Wiring (SessionServiceDecorator)
+
+**Test Plan Identifier:** TP-AF-056-PW
+**Issue:** #56
+**Version:** 2.0
+**Date:** 2026-05-08
+**Status:** Draft
+
+---
+
+## 1. Introduction
+
+This test plan validates the production wiring of `InvestigationSession` CRDs via a `SessionServiceDecorator` that enriches ADK's session creation flow with CRD-specific context. The decorator bridges the gap between the A2A executor (which calls `SessionService.Create` with an empty `State` map) and the `CRDSessionService` (which requires `CreateConfig` in `State` to populate the CRD).
+
+### 1.1 Scope
+
+- `SessionServiceDecorator`: transparent wrapper around `adksession.Service` that enriches `CreateRequest.State`
+- Context propagation: `BeforeExecuteCallback` stores task/user metadata in `context.Context`
+- Integration with launcher: decorator injected between executor and `CRDSessionService`
+- `af_sessions_active` gauge wiring in production path
+- Identity propagation: decorator extracts username from auth context
+
+### 1.2 Out of Scope
+
+- `CRDSessionService` CRUD operations (covered by TP-AF-056 v1.0)
+- State machine phase transitions (covered by TP-AF-056 v1.0)
+- TTL controller behavior (covered by TP-AF-056 v1.0)
+- SSE formatting (covered by TP-AF-056 v1.0)
+
+### 1.3 References
+
+- TP-AF-056 v1.0: CRD-backed Session Service test plan
+- ADR-005: Session persistence via InvestigationSession CRD
+- ARCHITECTURE.md Section 4: CRD Design (InvestigationSession)
+- ARCHITECTURE.md Section 7: Observability (`af_sessions_active`)
+- `google.golang.org/adk@v1.2.0/session.Service` interface
+- FedRAMP Controls: AC-3 (access enforcement), AU-2/AU-12 (audit)
+
+---
+
+## 2. Test Items
+
+| Item | Package | Source |
+|------|---------|--------|
+| `SessionServiceDecorator` | `internal/session` | New (this PR) |
+| `SessionCreateContext` | `internal/session` | New (this PR) |
+| `WithSessionCreateContext` / `SessionCreateContextFromContext` | `internal/session` | New (this PR) |
+| `buildBeforeExecuteCallback` (enriched) | `internal/launcher` | Modified |
+| `main.go` CRDSessionService wiring | `cmd/apifrontend` | Modified |
+
+---
+
+## 3. Business Acceptance Criteria
+
+| ID | Criterion | Source | Priority |
+|----|-----------|--------|----------|
+| BAC-56-PW-01 | A2A `message/send` creates `InvestigationSession` CRD with populated spec | ARCHITECTURE.md §4 | P0 |
+| BAC-56-PW-02 | CRD has labels including `kubernaut.ai/user` and `kubernaut.ai/rr-name` | ARCHITECTURE.md §4.2 | P0 |
+| BAC-56-PW-03 | `a2aTaskID` in CRD spec matches A2A task ID from request context | ARCHITECTURE.md §4.1 | P0 |
+| BAC-56-PW-04 | Reconnection via `List` by user label returns active sessions | Issue #56 AC | P0 |
+| BAC-56-PW-05 | Session creation without RR ref succeeds (exploratory triage) | Issue #56 AC | P1 |
+| BAC-56-PW-06 | Decorator is transparent — ADK runner behavior unchanged for Get/List/Delete/AppendEvent | ADK compat | P0 |
+| BAC-56-PW-07 | Invalid CRD name (non-RFC-1123 TaskID) is sanitized before CRD creation | K8s spec | P1 |
+| BAC-56-PW-08 | Empty/nil identity in context returns descriptive error, not silent failure | FedRAMP AC-3 | P0 |
+
+---
+
+## 4. Test Cases
+
+### 4.1 SessionServiceDecorator (8 tests)
+
+| ID | Description | BAC | Priority |
+|----|-------------|-----|----------|
+| UT-AF-056-PW-001 | Create enriches State with CreateConfig from context | BAC-56-PW-01 | P0 |
+| UT-AF-056-PW-002 | Create without context config passes through unchanged (transparent) | BAC-56-PW-06 | P0 |
+| UT-AF-056-PW-003 | Get/List/Delete/AppendEvent delegate to wrapped service unchanged | BAC-56-PW-06 | P0 |
+| UT-AF-056-PW-004 | TaskID extracted from context into CreateConfig.A2ATaskID | BAC-56-PW-03 | P0 |
+| UT-AF-056-PW-005 | UserIdentity populated from auth.UserIdentityFromContext | BAC-56-PW-02 | P0 |
+| UT-AF-056-PW-006 | Concurrent Create calls are safe (10 goroutines, -race) | Concurrency | P0 |
+| UT-AF-056-PW-007 | Invalid CRD name (non-RFC-1123 TaskID) is sanitized | BAC-56-PW-07 | P1 |
+| UT-AF-056-PW-008 | Empty username / nil identity yields error (not silent acceptance) | BAC-56-PW-08 | P0 |
+
+### 4.2 Context Propagation (4 tests)
+
+| ID | Description | BAC | Priority |
+|----|-------------|-----|----------|
+| UT-AF-056-PW-009 | WithSessionCreateContext stores and retrieves context value | BAC-56-PW-01 | P0 |
+| UT-AF-056-PW-010 | SessionCreateContextFromContext returns nil when not set | BAC-56-PW-06 | P0 |
+| UT-AF-056-PW-011 | BeforeExecuteCallback injects TaskID from RequestContext | BAC-56-PW-03 | P0 |
+| UT-AF-056-PW-012 | BeforeExecuteCallback injects UserIdentity from auth context | BAC-56-PW-02 | P0 |
+
+### 4.3 Integration (4 tests)
+
+| ID | Description | BAC | Priority |
+|----|-------------|-----|----------|
+| UT-AF-056-PW-013 | Full flow: A2A message/send -> decorator -> CRDSessionService -> CRD created | BAC-56-PW-01 | P0 |
+| UT-AF-056-PW-014 | Decorator + CRDSessionService with WithSessionsActive gauge updates metric | Observability | P0 |
+| UT-AF-056-PW-015 | Session creation without RR ref produces CRD with empty remediationRef | BAC-56-PW-05 | P1 |
+| UT-AF-056-PW-016 | Reconnection flow: create -> disconnect -> list by label -> reconnect | BAC-56-PW-04 | P0 |
+
+---
+
+## 5. Pass/Fail Criteria
+
+- All 16 tests pass with `-race` flag
+- Coverage >= 80% for `internal/session/decorator.go`
+- No exported test helpers from production packages
+- `golangci-lint run` reports 0 errors on modified files
+- Compile-time interface assertion: `var _ adksession.Service = (*SessionServiceDecorator)(nil)`
+
+---
+
+## 6. Test Environment
+
+- Go 1.25.6
+- `sigs.k8s.io/controller-runtime/pkg/client/fake` for K8s API simulation
+- `google.golang.org/adk/session.InMemoryService()` as inner delegate
+- Ginkgo v2 + Gomega test framework (ADR-015)
+- `-race` flag mandatory for concurrency tests
+
+---
+
+## 7. Design Notes
+
+### 7.1 Decorator Pattern
+
+```
+A2A Executor
+    |
+    v
+SessionServiceDecorator  <-- enriches Create with context data
+    |
+    v
+CRDSessionService        <-- persists to K8s CRD + delegates to InMemoryService
+    |
+    v
+adksession.InMemoryService()
+```
+
+### 7.2 Context Flow
+
+```
+HTTP Request (with JWT)
+    -> auth.Middleware (injects UserIdentity into context)
+    -> A2A JSON-RPC handler
+    -> BeforeExecuteCallback (injects SessionCreateContext with TaskID + UserIdentity)
+    -> ADK Runner calls SessionService.Create(ctx, req)
+    -> Decorator reads SessionCreateContext from ctx
+    -> Decorator builds CreateConfig and injects into req.State
+    -> CRDSessionService.Create reads CreateConfig from req.State
+    -> CRD created with populated spec/labels
+```

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/prometheus/prometheus v0.311.3
 	github.com/sony/gobreaker/v2 v2.4.0
 	go.uber.org/zap v1.27.1
+	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.15.0
 	google.golang.org/adk v1.2.0
 	google.golang.org/genai v1.40.0
@@ -117,7 +118,6 @@ require (
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -3,9 +3,11 @@
 package agent
 
 import (
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/dynamic"
 
 	"github.com/jordigilh/kubernaut-apifrontend/internal/audit"
+	"github.com/jordigilh/kubernaut-apifrontend/internal/auth"
 	"github.com/jordigilh/kubernaut-apifrontend/internal/ds"
 	"github.com/jordigilh/kubernaut-apifrontend/internal/ka"
 )
@@ -38,6 +40,13 @@ type AgentConfig struct {
 	MCPClient ka.MCPClient
 	// Auditor emits audit events for RBAC denials (FedRAMP SI-4).
 	Auditor audit.Emitter
+	// ToolCallsTotal is the af_tool_calls_total counter for observability wiring.
+	ToolCallsTotal *prometheus.CounterVec
+	// ToolCallDuration is the af_tool_call_duration_seconds histogram.
+	ToolCallDuration *prometheus.HistogramVec
+	// ImpersonatingClientFactory creates per-request impersonated dynamic clients
+	// for read-only triage tools (SEC-05). If nil, triage tools fall back to K8sClient.
+	ImpersonatingClientFactory auth.DynamicClientFactory
 }
 
 // Option applies a configuration override to AgentConfig.

--- a/internal/agent/prompt.txt
+++ b/internal/agent/prompt.txt
@@ -13,6 +13,8 @@ You are the Kubernaut API Frontend agent, an expert incident triage and remediat
 5. Use the most specific tool available rather than combining multiple lower-level operations.
 
 ## Tool Inventory
+
+### Remediation Management
 - kubernaut_list_remediations: List active remediations with filtering
 - kubernaut_get_remediation: Get detailed remediation status
 - kubernaut_submit_signal: Report a new incident signal
@@ -27,3 +29,11 @@ You are the Kubernaut API Frontend agent, an expert incident triage and remediat
 - kubernaut_get_remediation_history: Query historical remediations
 - kubernaut_get_effectiveness: Get workflow effectiveness scores
 - kubernaut_get_audit_trail: Retrieve audit trail for a remediation
+
+### NL Signal Intake (Triage)
+- af_list_events: List Kubernetes events filtered by namespace with optional reason/object filters
+- af_get_pods: Get pod status summaries including container states and conditions
+- af_get_workloads: List Deployment and StatefulSet health with replica counts and conditions
+- af_resolve_owner: Trace owner references from a resource to its root workload controller
+- af_check_existing_rr: Check for existing non-terminal remediation by fingerprint
+- af_create_rr: Create a new remediation with deduplication (prevents duplicate filings)

--- a/internal/agent/rbac_roles.yaml
+++ b/internal/agent/rbac_roles.yaml
@@ -14,6 +14,12 @@ roles:
     - kubernaut_get_remediation_history
     - kubernaut_get_effectiveness
     - kubernaut_get_audit_trail
+    - af_list_events
+    - af_get_pods
+    - af_get_workloads
+    - af_resolve_owner
+    - af_check_existing_rr
+    - af_create_rr
 
   ai-orchestrator:
     - kubernaut_list_remediations
@@ -26,6 +32,12 @@ roles:
     - kubernaut_poll_investigation
     - kubernaut_select_workflow
     - present_decision
+    - af_list_events
+    - af_get_pods
+    - af_get_workloads
+    - af_resolve_owner
+    - af_check_existing_rr
+    - af_create_rr
 
   cicd:
     - kubernaut_submit_signal
@@ -39,6 +51,9 @@ roles:
     - kubernaut_watch
     - kubernaut_get_effectiveness
     - kubernaut_list_workflows
+    - af_list_events
+    - af_get_pods
+    - af_get_workloads
 
   l3-audit:
     - kubernaut_list_remediations

--- a/internal/agent/root.go
+++ b/internal/agent/root.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/jordigilh/kubernaut-apifrontend/internal/audit"
 	"github.com/jordigilh/kubernaut-apifrontend/internal/auth"
+	"github.com/jordigilh/kubernaut-apifrontend/internal/security"
 	"github.com/jordigilh/kubernaut-apifrontend/internal/tools"
 )
 
@@ -239,8 +240,29 @@ func FilterToolsByRoles(roles []string, allTools []tool.Tool) []tool.Tool {
 // newMetricsToolCallbacks returns Before/After callbacks that track tool call
 // metrics: af_tool_calls_total (counter) and af_tool_call_duration_seconds (histogram).
 // Safe for concurrent use via sync.Map keyed by FunctionCallID.
+//
+// Leak analysis (SRE-1): entries are removed in `after` via LoadAndDelete. If `after`
+// never runs (panic/cancel), leaked entries are bounded by LLM call rate (typically
+// <100/min). Each entry is 24 bytes (time.Time). Worst case at 100 RPM with 100% loss
+// is ~140KB/day — negligible for a long-running service. A periodic sweep is added as
+// defense-in-depth.
 func newMetricsToolCallbacks(toolCalls *prometheus.CounterVec, toolDuration *prometheus.HistogramVec) (llmagent.BeforeToolCallback, llmagent.AfterToolCallback) {
 	var starts sync.Map
+
+	// Periodic sweep: evict entries older than 5 minutes (abandoned tool calls).
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			cutoff := time.Now().Add(-5 * time.Minute)
+			starts.Range(func(key, value any) bool {
+				if t, ok := value.(time.Time); ok && t.Before(cutoff) {
+					starts.Delete(key)
+				}
+				return true
+			})
+		}
+	}()
 
 	before := func(ctx tool.Context, _ tool.Tool, _ map[string]any) (map[string]any, error) {
 		if toolCalls == nil && toolDuration == nil {
@@ -291,7 +313,7 @@ func newAuditToolCallback(auditor audit.Emitter) llmagent.AfterToolCallback {
 			"result": result,
 		}
 		if toolErr != nil {
-			detail["error"] = toolErr.Error()
+			detail["error"] = security.RedactError(toolErr)
 		}
 		if ns, ok := input["namespace"].(string); ok && ns != "" {
 			detail["namespace"] = ns

--- a/internal/agent/root.go
+++ b/internal/agent/root.go
@@ -259,9 +259,11 @@ func newMetricsToolCallbacks(toolCalls *prometheus.CounterVec, toolDuration *pro
 			toolCalls.WithLabelValues(t.Name(), resultLabel).Inc()
 		}
 		if toolDuration != nil {
-			if start, ok := starts.LoadAndDelete(ctx.FunctionCallID()); ok {
-				elapsed := time.Since(start.(time.Time)).Seconds()
-				toolDuration.WithLabelValues(t.Name(), "function").Observe(elapsed)
+			if raw, ok := starts.LoadAndDelete(ctx.FunctionCallID()); ok {
+				if start, ok := raw.(time.Time); ok {
+					elapsed := time.Since(start).Seconds()
+					toolDuration.WithLabelValues(t.Name(), "function").Observe(elapsed)
+				}
 			}
 		}
 		return nil, nil

--- a/internal/agent/root.go
+++ b/internal/agent/root.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/llmagent"
 	"google.golang.org/adk/tool"
+
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/jordigilh/kubernaut-apifrontend/internal/audit"
 	"github.com/jordigilh/kubernaut-apifrontend/internal/auth"
@@ -69,12 +72,16 @@ func NewRootAgent(cfg AgentConfig, opts ...Option) (agent.Agent, []tool.Tool, er
 		return nil, nil, fmt.Errorf("tool list must not be empty: at least one tool is required")
 	}
 
+	beforeMetrics, afterMetrics := newMetricsToolCallbacks(cfg.ToolCallsTotal, cfg.ToolCallDuration)
+	afterAudit := newAuditToolCallback(cfg.Auditor)
+
 	a, err := llmagent.New(llmagent.Config{
 		Name:                "kubernaut-apifrontend",
 		Description:         "Kubernaut API Frontend agent for incident triage and remediation",
 		Tools:               allTools,
 		Instruction:         cfg.Instruction,
-		BeforeToolCallbacks: []llmagent.BeforeToolCallback{newRBACGuard(cfg.Auditor)},
+		BeforeToolCallbacks: []llmagent.BeforeToolCallback{newRBACGuard(cfg.Auditor), beforeMetrics},
+		AfterToolCallbacks:  []llmagent.AfterToolCallback{afterMetrics, afterAudit},
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating agent: %w", err)
@@ -100,6 +107,12 @@ func buildToolList(cfg AgentConfig) ([]tool.Tool, error) {
 	kaC := cfg.KAClient
 	mcpC := cfg.MCPClient
 
+	// Triage tools use impersonation; fall back to static SA client if no factory provided.
+	triageFactory := cfg.ImpersonatingClientFactory
+	if triageFactory == nil {
+		triageFactory = auth.StaticDynamicFactory(k8s)
+	}
+
 	constructors := []toolConstructor{
 		{"list_remediations", func() (tool.Tool, error) { return tools.NewListRemediationsTool(k8s) }},
 		{"get_remediation", func() (tool.Tool, error) { return tools.NewGetRemediationTool(k8s) }},
@@ -115,6 +128,14 @@ func buildToolList(cfg AgentConfig) ([]tool.Tool, error) {
 		{"get_remediation_history", func() (tool.Tool, error) { return tools.NewGetRemediationHistoryTool(dsC) }},
 		{"get_effectiveness", func() (tool.Tool, error) { return tools.NewGetEffectivenessTool(dsC) }},
 		{"get_audit_trail", func() (tool.Tool, error) { return tools.NewGetAuditTrailTool(dsC) }},
+		// NL Signal Intake tools (#52) — read-only tools use impersonation (SEC-05)
+		{"list_events", func() (tool.Tool, error) { return tools.NewListEventsTool(triageFactory) }},
+		{"get_pods", func() (tool.Tool, error) { return tools.NewGetPodsTool(triageFactory) }},
+		{"get_workloads", func() (tool.Tool, error) { return tools.NewGetWorkloadsTool(triageFactory) }},
+		{"resolve_owner", func() (tool.Tool, error) { return tools.NewResolveOwnerTool(triageFactory) }},
+		// RR tools use AF ServiceAccount (write AF-owned CRDs)
+		{"check_existing_rr", func() (tool.Tool, error) { return tools.NewCheckExistingRRTool(k8s) }},
+		{"create_rr", func() (tool.Tool, error) { return tools.NewCreateRRTool(k8s) }},
 	}
 
 	result := make([]tool.Tool, 0, len(constructors))
@@ -213,4 +234,78 @@ func FilterToolsByRoles(roles []string, allTools []tool.Tool) []tool.Tool {
 		}
 	}
 	return result
+}
+
+// newMetricsToolCallbacks returns Before/After callbacks that track tool call
+// metrics: af_tool_calls_total (counter) and af_tool_call_duration_seconds (histogram).
+// Safe for concurrent use via sync.Map keyed by FunctionCallID.
+func newMetricsToolCallbacks(toolCalls *prometheus.CounterVec, toolDuration *prometheus.HistogramVec) (llmagent.BeforeToolCallback, llmagent.AfterToolCallback) {
+	var starts sync.Map
+
+	before := func(ctx tool.Context, _ tool.Tool, _ map[string]any) (map[string]any, error) {
+		if toolCalls == nil && toolDuration == nil {
+			return nil, nil
+		}
+		starts.Store(ctx.FunctionCallID(), time.Now())
+		return nil, nil
+	}
+
+	after := func(ctx tool.Context, t tool.Tool, _, _ map[string]any, toolErr error) (map[string]any, error) {
+		resultLabel := "success"
+		if toolErr != nil {
+			resultLabel = "error"
+		}
+		if toolCalls != nil {
+			toolCalls.WithLabelValues(t.Name(), resultLabel).Inc()
+		}
+		if toolDuration != nil {
+			if start, ok := starts.LoadAndDelete(ctx.FunctionCallID()); ok {
+				elapsed := time.Since(start.(time.Time)).Seconds()
+				toolDuration.WithLabelValues(t.Name(), "function").Observe(elapsed)
+			}
+		}
+		return nil, nil
+	}
+
+	return before, after
+}
+
+// newAuditToolCallback returns an AfterToolCallback that emits a structured
+// audit event for every tool invocation (FedRAMP AU-12 compliance).
+// The event includes tool name, result status, and user identity.
+func newAuditToolCallback(auditor audit.Emitter) llmagent.AfterToolCallback {
+	return func(ctx tool.Context, t tool.Tool, input, _ map[string]any, toolErr error) (map[string]any, error) {
+		if auditor == nil {
+			return nil, nil
+		}
+
+		result := "success"
+		if toolErr != nil {
+			result = "error"
+		}
+
+		detail := map[string]string{
+			"tool":   t.Name(),
+			"result": result,
+		}
+		if toolErr != nil {
+			detail["error"] = toolErr.Error()
+		}
+		if ns, ok := input["namespace"].(string); ok && ns != "" {
+			detail["namespace"] = ns
+		}
+
+		userID := ""
+		if identity := auth.UserIdentityFromContext(ctx); identity != nil {
+			userID = identity.Username
+		}
+
+		auditor.Emit(ctx, &audit.Event{
+			Type:   audit.EventToolInvoked,
+			UserID: userID,
+			Detail: detail,
+		})
+
+		return nil, nil
+	}
 }

--- a/internal/agent/root_test.go
+++ b/internal/agent/root_test.go
@@ -1,6 +1,8 @@
 package agent_test
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -22,11 +24,11 @@ var _ = Describe("Root Agent", func() {
 			Expect(tools).NotTo(BeEmpty())
 		})
 
-		It("UT-AF-100-002: registers all 14 tools", func() {
+		It("UT-AF-100-002: registers all 20 tools", func() {
 			cfg := agentpkg.DefaultTestConfig()
 			_, tools, err := agentpkg.NewRootAgent(cfg)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(tools).To(HaveLen(14))
+			Expect(tools).To(HaveLen(20))
 		})
 
 		It("UT-AF-100-003: with nil model config returns error", func() {
@@ -48,7 +50,7 @@ var _ = Describe("Root Agent", func() {
 			}
 		})
 
-		It("UT-AF-100-005: tool names follow kubernaut_ prefix convention", func() {
+		It("UT-AF-100-005: tool names follow naming convention (kubernaut_ or af_ prefix)", func() {
 			cfg := agentpkg.DefaultTestConfig()
 			_, tools, err := agentpkg.NewRootAgent(cfg)
 			Expect(err).NotTo(HaveOccurred())
@@ -57,7 +59,8 @@ var _ = Describe("Root Agent", func() {
 				if t.Name() == "present_decision" {
 					continue
 				}
-				Expect(t.Name()).To(HavePrefix("kubernaut_"), "tool %q missing kubernaut_ prefix", t.Name())
+				hasValidPrefix := strings.HasPrefix(t.Name(), "kubernaut_") || strings.HasPrefix(t.Name(), "af_")
+				Expect(hasValidPrefix).To(BeTrue(), "tool %q missing kubernaut_ or af_ prefix", t.Name())
 			}
 		})
 
@@ -75,7 +78,7 @@ var _ = Describe("Root Agent", func() {
 			cfg := agentpkg.DefaultTestConfig()
 			_, tools, err := agentpkg.NewRootAgent(cfg)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(tools).To(HaveLen(14))
+			Expect(tools).To(HaveLen(20))
 		})
 
 		It("UT-AF-100-008: present_decision is marked IsLongRunning", func() {
@@ -118,7 +121,7 @@ var _ = Describe("Root Agent", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			filtered := agentpkg.FilterToolsByRole("sre", tools)
-			Expect(filtered).To(HaveLen(14))
+			Expect(filtered).To(HaveLen(20))
 
 			filtered = agentpkg.FilterToolsByRole("unknown-role", tools)
 			Expect(filtered).To(BeEmpty())

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -35,7 +35,8 @@ const (
 	EventConfigReloaded EventType = "config.reloaded"
 	EventConfigRejected EventType = "config.rejected"
 
-	EventRBACDenied EventType = "rbac.denied"
+	EventRBACDenied  EventType = "rbac.denied"
+	EventToolInvoked EventType = "tool.invoked"
 )
 
 // Event represents a SOC2-compatible audit event.

--- a/internal/auth/dynamic_impersonation.go
+++ b/internal/auth/dynamic_impersonation.go
@@ -1,0 +1,50 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+// DynamicClientFactory creates a dynamic.Interface appropriate for the calling
+// user's identity. Read-only triage tools use this to enforce least-privilege:
+// the user only sees what their RBAC permits, not the AF ServiceAccount's broader view.
+type DynamicClientFactory func(ctx context.Context) (dynamic.Interface, error)
+
+// NewImpersonatingDynamicFactory returns a DynamicClientFactory that creates an
+// impersonated dynamic.Interface based on the UserIdentity in the context.
+// If no identity is present, it returns an error (fail-closed).
+// baseCfg is the AF ServiceAccount's rest.Config (never mutated).
+func NewImpersonatingDynamicFactory(baseCfg *rest.Config) DynamicClientFactory {
+	return func(ctx context.Context) (dynamic.Interface, error) {
+		identity := UserIdentityFromContext(ctx)
+		if identity == nil || identity.Username == "" {
+			return nil, fmt.Errorf("impersonation requires authenticated user identity in context")
+		}
+
+		impCfg, err := NewImpersonatedConfig(baseCfg, identity.Username, identity.Groups)
+		if err != nil {
+			return nil, fmt.Errorf("creating impersonated config: %w", err)
+		}
+
+		client, err := dynamic.NewForConfig(impCfg)
+		if err != nil {
+			return nil, fmt.Errorf("creating impersonated dynamic client: %w", err)
+		}
+
+		return client, nil
+	}
+}
+
+// StaticDynamicFactory returns a DynamicClientFactory that always returns the
+// same client. Used for AF ServiceAccount-scoped tools and testing.
+func StaticDynamicFactory(client dynamic.Interface) DynamicClientFactory {
+	return func(_ context.Context) (dynamic.Interface, error) {
+		if client == nil {
+			return nil, fmt.Errorf("kubernetes cluster is not available — contact your administrator")
+		}
+		return client, nil
+	}
+}

--- a/internal/auth/dynamic_impersonation.go
+++ b/internal/auth/dynamic_impersonation.go
@@ -13,11 +13,17 @@ import (
 // the user only sees what their RBAC permits, not the AF ServiceAccount's broader view.
 type DynamicClientFactory func(ctx context.Context) (dynamic.Interface, error)
 
+// ClientWrapper optionally wraps a dynamic.Interface with additional behavior
+// (e.g., circuit breaker). Used by NewImpersonatingDynamicFactory to protect
+// impersonated clients with the shared K8s circuit breaker.
+type ClientWrapper func(dynamic.Interface) dynamic.Interface
+
 // NewImpersonatingDynamicFactory returns a DynamicClientFactory that creates an
 // impersonated dynamic.Interface based on the UserIdentity in the context.
 // If no identity is present, it returns an error (fail-closed).
 // baseCfg is the AF ServiceAccount's rest.Config (never mutated).
-func NewImpersonatingDynamicFactory(baseCfg *rest.Config) DynamicClientFactory {
+// wrappers are applied in order to the raw client (typically circuit breaker).
+func NewImpersonatingDynamicFactory(baseCfg *rest.Config, wrappers ...ClientWrapper) DynamicClientFactory {
 	return func(ctx context.Context) (dynamic.Interface, error) {
 		identity := UserIdentityFromContext(ctx)
 		if identity == nil || identity.Username == "" {
@@ -34,7 +40,11 @@ func NewImpersonatingDynamicFactory(baseCfg *rest.Config) DynamicClientFactory {
 			return nil, fmt.Errorf("creating impersonated dynamic client: %w", err)
 		}
 
-		return client, nil
+		var wrapped dynamic.Interface = client
+		for _, w := range wrappers {
+			wrapped = w(wrapped)
+		}
+		return wrapped, nil
 	}
 }
 

--- a/internal/auth/dynamic_impersonation_test.go
+++ b/internal/auth/dynamic_impersonation_test.go
@@ -1,0 +1,92 @@
+package auth_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+
+	"github.com/jordigilh/kubernaut-apifrontend/internal/auth"
+)
+
+var _ = Describe("DynamicClientFactory", func() {
+	Describe("NewImpersonatingDynamicFactory", func() {
+		var baseCfg *rest.Config
+
+		BeforeEach(func() {
+			baseCfg = &rest.Config{
+				Host: "https://fake-api-server:6443",
+			}
+		})
+
+		It("UT-AF-IMP-001: returns error when no identity in context", func() {
+			factory := auth.NewImpersonatingDynamicFactory(baseCfg)
+			_, err := factory(context.Background())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("impersonation requires authenticated user identity"))
+		})
+
+		It("UT-AF-IMP-002: returns error when username is empty", func() {
+			factory := auth.NewImpersonatingDynamicFactory(baseCfg)
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+				Username: "",
+				Groups:   []string{"sre"},
+			})
+			_, err := factory(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("impersonation requires authenticated user identity"))
+		})
+
+		It("UT-AF-IMP-003: creates client successfully with valid identity", func() {
+			factory := auth.NewImpersonatingDynamicFactory(baseCfg)
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+				Username: "alice",
+				Groups:   []string{"sre", "ops"},
+			})
+			client, err := factory(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).NotTo(BeNil())
+		})
+
+		It("UT-AF-IMP-004: applies client wrappers in order", func() {
+			var wrapperCalled bool
+			wrapper := auth.ClientWrapper(func(c dynamic.Interface) dynamic.Interface {
+				wrapperCalled = true
+				return c
+			})
+
+			factory := auth.NewImpersonatingDynamicFactory(baseCfg, wrapper)
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+				Username: "bob",
+				Groups:   []string{"sre"},
+			})
+			client, err := factory(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).NotTo(BeNil())
+			Expect(wrapperCalled).To(BeTrue())
+		})
+	})
+
+	Describe("StaticDynamicFactory", func() {
+		It("UT-AF-IMP-005: returns error when client is nil", func() {
+			factory := auth.StaticDynamicFactory(nil)
+			_, err := factory(context.Background())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("kubernetes cluster is not available"))
+		})
+
+		It("UT-AF-IMP-006: returns the static client when non-nil", func() {
+			fakeClient := &fakeDynamicInterface{}
+			factory := auth.StaticDynamicFactory(fakeClient)
+			client, err := factory(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).To(Equal(fakeClient))
+		})
+	})
+})
+
+// fakeDynamicInterface is a minimal stub satisfying dynamic.Interface for tests.
+type fakeDynamicInterface struct{ dynamic.Interface }

--- a/internal/auth/rbac_tools_test.go
+++ b/internal/auth/rbac_tools_test.go
@@ -20,11 +20,11 @@ var _ = Describe("FilterToolsByRole", func() {
 		}
 	})
 
-	It("UT-AF-130-001: SRE role gets all 14 tools", func() {
+	It("UT-AF-130-001: SRE role gets all 20 tools", func() {
 		cfg := agent.DefaultTestConfig()
 		_, tools, _ := agent.NewRootAgent(cfg)
 		filtered := agent.FilterToolsByRole("sre", tools)
-		Expect(filtered).To(HaveLen(14))
+		Expect(filtered).To(HaveLen(20))
 	})
 
 	It("UT-AF-130-002: CI/CD role gets submit_signal, list, watch, get only", func() {
@@ -61,18 +61,18 @@ var _ = Describe("FilterToolsByRole", func() {
 		))
 	})
 
-	It("UT-AF-130-004: AI Orchestrator role gets investigation + CRD tools", func() {
+	It("UT-AF-130-004: AI Orchestrator role gets investigation + CRD + triage tools", func() {
 		cfg := agent.DefaultTestConfig()
 		_, tools, _ := agent.NewRootAgent(cfg)
 		filtered := agent.FilterToolsByRole("ai-orchestrator", tools)
-		Expect(filtered).To(HaveLen(10))
+		Expect(filtered).To(HaveLen(16))
 	})
 
-	It("UT-AF-130-005: Observability Dashboard role gets list, get, watch, effectiveness, workflows", func() {
+	It("UT-AF-130-005: Observability Dashboard role gets list, get, watch, effectiveness, workflows + triage read tools", func() {
 		cfg := agent.DefaultTestConfig()
 		_, tools, _ := agent.NewRootAgent(cfg)
 		filtered := agent.FilterToolsByRole("observability", tools)
-		Expect(filtered).To(HaveLen(5))
+		Expect(filtered).To(HaveLen(8))
 	})
 
 	It("UT-AF-130-006: unknown role gets empty tool list", func() {

--- a/internal/handler/agentcard_test.go
+++ b/internal/handler/agentcard_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Agent Card Handler", func() {
 		_ = json.Unmarshal(rec.Body.Bytes(), &card)
 		skills, ok := card["skills"].([]any)
 		Expect(ok).To(BeTrue())
-		Expect(skills).To(HaveLen(14))
+		Expect(skills).To(HaveLen(20))
 	})
 
 	It("UT-AF-230-008: card declares authentication requirements", func() {

--- a/internal/handler/mcp_conformance_test.go
+++ b/internal/handler/mcp_conformance_test.go
@@ -143,10 +143,10 @@ var _ = Describe("MCP Protocol Conformance", func() {
 			Expect(ok).To(BeTrue())
 			tools, ok := resultObj["tools"].([]any)
 			Expect(ok).To(BeTrue())
-			Expect(tools).To(HaveLen(14))
+			Expect(tools).To(HaveLen(20))
 		})
 
-		It("UT-AF-042-002: all tool names have kubernaut_ prefix", func() {
+		It("UT-AF-042-002: all tool names have kubernaut_ or af_ prefix", func() {
 			sessionID := initializeSession(mcpHandler)
 			rec := sendWithSession(mcpHandler, sessionID, "tools/list", 2, nil)
 
@@ -160,7 +160,8 @@ var _ = Describe("MCP Protocol Conformance", func() {
 				Expect(ok).To(BeTrue())
 				name, ok := tool["name"].(string)
 				Expect(ok).To(BeTrue())
-				Expect(name).To(HavePrefix("kubernaut_"))
+				hasValid := strings.HasPrefix(name, "kubernaut_") || strings.HasPrefix(name, "af_")
+				Expect(hasValid).To(BeTrue(), "tool %q missing kubernaut_ or af_ prefix", name)
 			}
 		})
 

--- a/internal/handler/mcp_test.go
+++ b/internal/handler/mcp_test.go
@@ -83,16 +83,17 @@ var _ = Describe("MCP Handler", func() {
 		Expect(toolHandler).NotTo(BeNil())
 	})
 
-	It("UT-AF-220-005: tools registered include kubernaut_ prefix", func() {
+	It("UT-AF-220-005: tools registered include kubernaut_ or af_ prefix", func() {
 		tools := handler.DefaultMCPTools()
 		for _, t := range tools {
-			Expect(t.Name).To(HavePrefix("kubernaut_"))
+			hasValid := strings.HasPrefix(t.Name, "kubernaut_") || strings.HasPrefix(t.Name, "af_")
+			Expect(hasValid).To(BeTrue(), "tool %q missing kubernaut_ or af_ prefix", t.Name)
 		}
 	})
 
-	It("UT-AF-220-006: tools count matches 14 expected tools", func() {
+	It("UT-AF-220-006: tools count matches 20 expected tools", func() {
 		tools := handler.DefaultMCPTools()
-		Expect(tools).To(HaveLen(14))
+		Expect(tools).To(HaveLen(20))
 	})
 
 	It("UT-AF-220-007: MCP server info includes correct name and version", func() {

--- a/internal/handler/mcptools.go
+++ b/internal/handler/mcptools.go
@@ -17,4 +17,10 @@ var mcpToolRegistry = []MCPToolDef{
 	{Name: "kubernaut_get_remediation_history", Description: "Get remediation execution history"},
 	{Name: "kubernaut_get_effectiveness", Description: "Get remediation effectiveness metrics"},
 	{Name: "kubernaut_get_audit_trail", Description: "Get audit trail for remediations"},
+	{Name: "af_list_events", Description: "List Kubernetes events filtered by namespace with optional reason/object filters"},
+	{Name: "af_get_pods", Description: "Get pod status summaries including container states and conditions"},
+	{Name: "af_get_workloads", Description: "List Deployment and StatefulSet health with replica counts"},
+	{Name: "af_resolve_owner", Description: "Trace owner references from a resource to its root workload"},
+	{Name: "af_check_existing_rr", Description: "Check for existing non-terminal RemediationRequest by fingerprint"},
+	{Name: "af_create_rr", Description: "Create a RemediationRequest with singleflight deduplication"},
 }

--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jordigilh/kubernaut-apifrontend/internal/audit"
 	"github.com/jordigilh/kubernaut-apifrontend/internal/auth"
 	"github.com/jordigilh/kubernaut-apifrontend/internal/security"
+	"github.com/jordigilh/kubernaut-apifrontend/internal/session"
 )
 
 // A2AConfig holds the configuration for the A2A JSON-RPC handler.
@@ -81,6 +82,7 @@ func NewA2AHandler(cfg A2AConfig) (http.Handler, error) { //nolint:gocritic // h
 
 // buildBeforeExecuteCallback wraps the user-supplied callback and emits an
 // audit event when an A2A task starts (AU-2 compliance).
+// It also injects SessionCreateContext so the decorator can enrich session creation.
 func buildBeforeExecuteCallback(userCb func(ctx context.Context) (context.Context, error), auditor audit.Emitter) adka2a.BeforeExecuteCallback {
 	return func(ctx context.Context, reqCtx *a2asrv.RequestContext) (context.Context, error) {
 		user := auth.UserIdentityFromContext(ctx)
@@ -99,6 +101,15 @@ func buildBeforeExecuteCallback(userCb func(ctx context.Context) (context.Contex
 				UserID: username,
 				Detail: detail,
 			})
+		}
+
+		// Inject session creation context for the SessionServiceDecorator.
+		// The decorator reads this to build CreateConfig with task/user metadata.
+		if reqCtx != nil {
+			sc := &session.SessionCreateContext{
+				TaskID: string(reqCtx.TaskID),
+			}
+			ctx = session.WithSessionCreateContext(ctx, sc)
 		}
 
 		if userCb != nil {

--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -82,7 +82,7 @@ func NewA2AHandler(cfg A2AConfig) (http.Handler, error) { //nolint:gocritic // h
 
 // buildBeforeExecuteCallback wraps the user-supplied callback and emits an
 // audit event when an A2A task starts (AU-2 compliance).
-// It also injects SessionCreateContext so the decorator can enrich session creation.
+// It also injects CreateContext so the decorator can enrich session creation.
 func buildBeforeExecuteCallback(userCb func(ctx context.Context) (context.Context, error), auditor audit.Emitter) adka2a.BeforeExecuteCallback {
 	return func(ctx context.Context, reqCtx *a2asrv.RequestContext) (context.Context, error) {
 		user := auth.UserIdentityFromContext(ctx)
@@ -103,13 +103,13 @@ func buildBeforeExecuteCallback(userCb func(ctx context.Context) (context.Contex
 			})
 		}
 
-		// Inject session creation context for the SessionServiceDecorator.
+		// Inject session creation context for the ServiceDecorator.
 		// The decorator reads this to build CreateConfig with task/user metadata.
 		if reqCtx != nil {
-			sc := &session.SessionCreateContext{
+			sc := &session.CreateContext{
 				TaskID: string(reqCtx.TaskID),
 			}
-			ctx = session.WithSessionCreateContext(ctx, sc)
+			ctx = session.WithCreateContext(ctx, sc)
 		}
 
 		if userCb != nil {

--- a/internal/session/decorator.go
+++ b/internal/session/decorator.go
@@ -1,0 +1,99 @@
+package session
+
+import (
+	"context"
+	"fmt"
+
+	adksession "google.golang.org/adk/session"
+
+	"github.com/jordigilh/kubernaut-apifrontend/api/apifrontend/v1alpha1"
+	"github.com/jordigilh/kubernaut-apifrontend/internal/auth"
+)
+
+type sessionCreateContextKey struct{}
+
+// SessionCreateContext carries A2A task metadata through the context for
+// the decorator to inject into the session creation request.
+type SessionCreateContext struct {
+	TaskID         string
+	RemediationRef v1alpha1.ObjectRef
+}
+
+// WithSessionCreateContext returns a context enriched with session creation metadata.
+func WithSessionCreateContext(ctx context.Context, sc *SessionCreateContext) context.Context {
+	return context.WithValue(ctx, sessionCreateContextKey{}, sc)
+}
+
+// SessionCreateContextFromContext extracts the SessionCreateContext. Returns nil if not set.
+func SessionCreateContextFromContext(ctx context.Context) *SessionCreateContext {
+	v, _ := ctx.Value(sessionCreateContextKey{}).(*SessionCreateContext)
+	return v
+}
+
+// SessionServiceDecorator wraps an adksession.Service and enriches Create
+// requests with CRD metadata from context. All other methods delegate unchanged.
+type SessionServiceDecorator struct {
+	inner adksession.Service
+}
+
+// NewSessionServiceDecorator creates a decorator that wraps the given service.
+// Panics if inner is nil (programming error — caught at startup, not runtime).
+func NewSessionServiceDecorator(inner adksession.Service) *SessionServiceDecorator {
+	if inner == nil {
+		panic("session.NewSessionServiceDecorator: inner service must not be nil")
+	}
+	return &SessionServiceDecorator{inner: inner}
+}
+
+// Create enriches the request State with CreateConfig extracted from context,
+// then delegates to the inner service.
+func (d *SessionServiceDecorator) Create(ctx context.Context, req *adksession.CreateRequest) (*adksession.CreateResponse, error) {
+	sc := SessionCreateContextFromContext(ctx)
+	if sc == nil {
+		return d.inner.Create(ctx, req)
+	}
+
+	identity := auth.UserIdentityFromContext(ctx)
+	if identity == nil || identity.Username == "" {
+		return nil, fmt.Errorf("session creation requires authenticated user identity")
+	}
+
+	cfg := &CreateConfig{
+		A2ATaskID: sc.TaskID,
+		UserIdentity: v1alpha1.SessionUser{
+			Username: identity.Username,
+			Groups:   identity.Groups,
+		},
+		RemediationRef: sc.RemediationRef,
+	}
+
+	if req.State == nil {
+		req.State = make(map[string]any)
+	}
+	req.State[StateKeyCreateConfig] = cfg
+
+	return d.inner.Create(ctx, req)
+}
+
+// Get delegates to the inner service.
+func (d *SessionServiceDecorator) Get(ctx context.Context, req *adksession.GetRequest) (*adksession.GetResponse, error) {
+	return d.inner.Get(ctx, req)
+}
+
+// List delegates to the inner service.
+func (d *SessionServiceDecorator) List(ctx context.Context, req *adksession.ListRequest) (*adksession.ListResponse, error) {
+	return d.inner.List(ctx, req)
+}
+
+// Delete delegates to the inner service.
+func (d *SessionServiceDecorator) Delete(ctx context.Context, req *adksession.DeleteRequest) error {
+	return d.inner.Delete(ctx, req)
+}
+
+// AppendEvent delegates to the inner service.
+func (d *SessionServiceDecorator) AppendEvent(ctx context.Context, sess adksession.Session, event *adksession.Event) error {
+	return d.inner.AppendEvent(ctx, sess, event)
+}
+
+// Compile-time interface assertion.
+var _ adksession.Service = (*SessionServiceDecorator)(nil)

--- a/internal/session/decorator.go
+++ b/internal/session/decorator.go
@@ -12,43 +12,43 @@ import (
 
 type sessionCreateContextKey struct{}
 
-// SessionCreateContext carries A2A task metadata through the context for
+// CreateContext carries A2A task metadata through the context for
 // the decorator to inject into the session creation request.
-type SessionCreateContext struct {
+type CreateContext struct {
 	TaskID         string
 	RemediationRef v1alpha1.ObjectRef
 }
 
-// WithSessionCreateContext returns a context enriched with session creation metadata.
-func WithSessionCreateContext(ctx context.Context, sc *SessionCreateContext) context.Context {
+// WithCreateContext returns a context enriched with session creation metadata.
+func WithCreateContext(ctx context.Context, sc *CreateContext) context.Context {
 	return context.WithValue(ctx, sessionCreateContextKey{}, sc)
 }
 
-// SessionCreateContextFromContext extracts the SessionCreateContext. Returns nil if not set.
-func SessionCreateContextFromContext(ctx context.Context) *SessionCreateContext {
-	v, _ := ctx.Value(sessionCreateContextKey{}).(*SessionCreateContext)
+// CreateContextFromContext extracts the CreateContext. Returns nil if not set.
+func CreateContextFromContext(ctx context.Context) *CreateContext {
+	v, _ := ctx.Value(sessionCreateContextKey{}).(*CreateContext)
 	return v
 }
 
-// SessionServiceDecorator wraps an adksession.Service and enriches Create
+// ServiceDecorator wraps an adksession.Service and enriches Create
 // requests with CRD metadata from context. All other methods delegate unchanged.
-type SessionServiceDecorator struct {
+type ServiceDecorator struct {
 	inner adksession.Service
 }
 
-// NewSessionServiceDecorator creates a decorator that wraps the given service.
+// NewServiceDecorator creates a decorator that wraps the given service.
 // Panics if inner is nil (programming error — caught at startup, not runtime).
-func NewSessionServiceDecorator(inner adksession.Service) *SessionServiceDecorator {
+func NewServiceDecorator(inner adksession.Service) *ServiceDecorator {
 	if inner == nil {
-		panic("session.NewSessionServiceDecorator: inner service must not be nil")
+		panic("session.NewServiceDecorator: inner service must not be nil")
 	}
-	return &SessionServiceDecorator{inner: inner}
+	return &ServiceDecorator{inner: inner}
 }
 
 // Create enriches the request State with CreateConfig extracted from context,
 // then delegates to the inner service.
-func (d *SessionServiceDecorator) Create(ctx context.Context, req *adksession.CreateRequest) (*adksession.CreateResponse, error) {
-	sc := SessionCreateContextFromContext(ctx)
+func (d *ServiceDecorator) Create(ctx context.Context, req *adksession.CreateRequest) (*adksession.CreateResponse, error) {
+	sc := CreateContextFromContext(ctx)
 	if sc == nil {
 		return d.inner.Create(ctx, req)
 	}
@@ -76,24 +76,24 @@ func (d *SessionServiceDecorator) Create(ctx context.Context, req *adksession.Cr
 }
 
 // Get delegates to the inner service.
-func (d *SessionServiceDecorator) Get(ctx context.Context, req *adksession.GetRequest) (*adksession.GetResponse, error) {
+func (d *ServiceDecorator) Get(ctx context.Context, req *adksession.GetRequest) (*adksession.GetResponse, error) {
 	return d.inner.Get(ctx, req)
 }
 
 // List delegates to the inner service.
-func (d *SessionServiceDecorator) List(ctx context.Context, req *adksession.ListRequest) (*adksession.ListResponse, error) {
+func (d *ServiceDecorator) List(ctx context.Context, req *adksession.ListRequest) (*adksession.ListResponse, error) {
 	return d.inner.List(ctx, req)
 }
 
 // Delete delegates to the inner service.
-func (d *SessionServiceDecorator) Delete(ctx context.Context, req *adksession.DeleteRequest) error {
+func (d *ServiceDecorator) Delete(ctx context.Context, req *adksession.DeleteRequest) error {
 	return d.inner.Delete(ctx, req)
 }
 
 // AppendEvent delegates to the inner service.
-func (d *SessionServiceDecorator) AppendEvent(ctx context.Context, sess adksession.Session, event *adksession.Event) error {
+func (d *ServiceDecorator) AppendEvent(ctx context.Context, sess adksession.Session, event *adksession.Event) error {
 	return d.inner.AppendEvent(ctx, sess, event)
 }
 
 // Compile-time interface assertion.
-var _ adksession.Service = (*SessionServiceDecorator)(nil)
+var _ adksession.Service = (*ServiceDecorator)(nil)

--- a/internal/session/decorator.go
+++ b/internal/session/decorator.go
@@ -15,7 +15,11 @@ type sessionCreateContextKey struct{}
 // CreateContext carries A2A task metadata through the context for
 // the decorator to inject into the session creation request.
 type CreateContext struct {
-	TaskID         string
+	TaskID string
+	// TODO(v1.6): RemediationRef is a forward-compatibility placeholder.
+	// It will be populated when the A2A protocol carries remediation context
+	// in the task params (tracked in issue #54). Currently only TaskID is set
+	// by the BeforeExecuteCallback in launcher.go.
 	RemediationRef v1alpha1.ObjectRef
 }
 

--- a/internal/session/decorator_test.go
+++ b/internal/session/decorator_test.go
@@ -39,14 +39,27 @@ var _ = Describe("ServiceDecorator", func() {
 				},
 			})
 
-			resp, err := decorator.Create(ctx, &adksession.CreateRequest{
+			req := &adksession.CreateRequest{
 				AppName: "test-app",
 				UserID:  "alice",
-			})
+			}
+			resp, err := decorator.Create(ctx, req)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp).NotTo(BeNil())
 			Expect(resp.Session).NotTo(BeNil())
+
+			// Assert enriched State contents (TQ-2 review)
+			Expect(req.State).NotTo(BeNil())
+			raw, ok := req.State[session.StateKeyCreateConfig]
+			Expect(ok).To(BeTrue(), "State must contain StateKeyCreateConfig")
+			cfg, ok := raw.(*session.CreateConfig)
+			Expect(ok).To(BeTrue(), "value must be *CreateConfig")
+			Expect(cfg.A2ATaskID).To(Equal("task-123"))
+			Expect(cfg.UserIdentity.Username).To(Equal("alice"))
+			Expect(cfg.UserIdentity.Groups).To(ConsistOf("sre"))
+			Expect(cfg.RemediationRef.Namespace).To(Equal("prod"))
+			Expect(cfg.RemediationRef.Name).To(Equal("rr-fix-oom"))
 		})
 
 		It("UT-AF-056-PW-002: passes through unchanged when no context config", func() {

--- a/internal/session/decorator_test.go
+++ b/internal/session/decorator_test.go
@@ -14,16 +14,16 @@ import (
 	"github.com/jordigilh/kubernaut-apifrontend/internal/session"
 )
 
-var _ = Describe("SessionServiceDecorator", func() {
+var _ = Describe("ServiceDecorator", func() {
 	var (
 		inner     adksession.Service
-		decorator *session.SessionServiceDecorator
+		decorator *session.ServiceDecorator
 		ctx       context.Context
 	)
 
 	BeforeEach(func() {
 		inner = adksession.InMemoryService()
-		decorator = session.NewSessionServiceDecorator(inner)
+		decorator = session.NewServiceDecorator(inner)
 		ctx = context.Background()
 	})
 
@@ -31,7 +31,7 @@ var _ = Describe("SessionServiceDecorator", func() {
 		It("UT-AF-056-PW-001: enriches State with CreateConfig from context", func() {
 			identity := &auth.UserIdentity{Username: "alice", Groups: []string{"sre"}}
 			ctx = auth.WithUserIdentity(ctx, identity)
-			ctx = session.WithSessionCreateContext(ctx, &session.SessionCreateContext{
+			ctx = session.WithCreateContext(ctx, &session.CreateContext{
 				TaskID: "task-123",
 				RemediationRef: v1alpha1.ObjectRef{
 					Namespace: "prod",
@@ -63,7 +63,7 @@ var _ = Describe("SessionServiceDecorator", func() {
 		It("UT-AF-056-PW-004: TaskID extracted from context into CreateConfig.A2ATaskID", func() {
 			identity := &auth.UserIdentity{Username: "carol", Groups: []string{"sre"}}
 			ctx = auth.WithUserIdentity(ctx, identity)
-			ctx = session.WithSessionCreateContext(ctx, &session.SessionCreateContext{
+			ctx = session.WithCreateContext(ctx, &session.CreateContext{
 				TaskID: "task-abc-def",
 			})
 
@@ -71,7 +71,7 @@ var _ = Describe("SessionServiceDecorator", func() {
 			scheme := newScheme()
 			k8s := newFakeClient(scheme)
 			crdSvc := session.NewCRDSessionService(adksession.InMemoryService(), k8s, scheme, "test-ns")
-			dec := session.NewSessionServiceDecorator(crdSvc)
+			dec := session.NewServiceDecorator(crdSvc)
 
 			resp, err := dec.Create(ctx, &adksession.CreateRequest{
 				AppName: "test-app",
@@ -86,14 +86,14 @@ var _ = Describe("SessionServiceDecorator", func() {
 		It("UT-AF-056-PW-005: UserIdentity populated from auth context", func() {
 			identity := &auth.UserIdentity{Username: "dave", Groups: []string{"l1-ops", "sre"}}
 			ctx = auth.WithUserIdentity(ctx, identity)
-			ctx = session.WithSessionCreateContext(ctx, &session.SessionCreateContext{
+			ctx = session.WithCreateContext(ctx, &session.CreateContext{
 				TaskID: "task-user-test",
 			})
 
 			scheme := newScheme()
 			k8s := newFakeClient(scheme)
 			crdSvc := session.NewCRDSessionService(adksession.InMemoryService(), k8s, scheme, "test-ns")
-			dec := session.NewSessionServiceDecorator(crdSvc)
+			dec := session.NewServiceDecorator(crdSvc)
 
 			resp, err := dec.Create(ctx, &adksession.CreateRequest{
 				AppName: "test-app",
@@ -107,7 +107,7 @@ var _ = Describe("SessionServiceDecorator", func() {
 		It("UT-AF-056-PW-006: concurrent Create calls are safe under -race", func() {
 			identity := &auth.UserIdentity{Username: "eve", Groups: []string{"sre"}}
 			ctx = auth.WithUserIdentity(ctx, identity)
-			ctx = session.WithSessionCreateContext(ctx, &session.SessionCreateContext{
+			ctx = session.WithCreateContext(ctx, &session.CreateContext{
 				TaskID: "task-concurrent",
 			})
 
@@ -133,7 +133,7 @@ var _ = Describe("SessionServiceDecorator", func() {
 		It("UT-AF-056-PW-007: non-RFC-1123 TaskID is passed to inner service for sanitization", func() {
 			identity := &auth.UserIdentity{Username: "grace", Groups: []string{"sre"}}
 			ctx = auth.WithUserIdentity(ctx, identity)
-			ctx = session.WithSessionCreateContext(ctx, &session.SessionCreateContext{
+			ctx = session.WithCreateContext(ctx, &session.CreateContext{
 				TaskID: "UPPER-CASE_with/slashes/../traversal",
 			})
 
@@ -141,7 +141,7 @@ var _ = Describe("SessionServiceDecorator", func() {
 			scheme := newScheme()
 			k8s := newFakeClient(scheme)
 			crdSvc := session.NewCRDSessionService(adksession.InMemoryService(), k8s, scheme, "test-ns")
-			dec := session.NewSessionServiceDecorator(crdSvc)
+			dec := session.NewServiceDecorator(crdSvc)
 
 			resp, err := dec.Create(ctx, &adksession.CreateRequest{
 				AppName: "test-app",
@@ -154,7 +154,7 @@ var _ = Describe("SessionServiceDecorator", func() {
 		})
 
 		It("UT-AF-056-PW-008: empty username / nil identity yields error", func() {
-			ctx = session.WithSessionCreateContext(ctx, &session.SessionCreateContext{
+			ctx = session.WithCreateContext(ctx, &session.CreateContext{
 				TaskID: "task-no-identity",
 			})
 
@@ -214,16 +214,16 @@ var _ = Describe("SessionServiceDecorator", func() {
 	})
 
 	Describe("Context helpers", func() {
-		It("UT-AF-056-PW-009: WithSessionCreateContext stores and retrieves value", func() {
-			sc := &session.SessionCreateContext{
+		It("UT-AF-056-PW-009: WithCreateContext stores and retrieves value", func() {
+			sc := &session.CreateContext{
 				TaskID: "test-task",
 				RemediationRef: v1alpha1.ObjectRef{
 					Namespace: "ns1",
 					Name:      "rr-1",
 				},
 			}
-			enriched := session.WithSessionCreateContext(ctx, sc)
-			retrieved := session.SessionCreateContextFromContext(enriched)
+			enriched := session.WithCreateContext(ctx, sc)
+			retrieved := session.CreateContextFromContext(enriched)
 
 			Expect(retrieved).NotTo(BeNil())
 			Expect(retrieved.TaskID).To(Equal("test-task"))
@@ -231,8 +231,8 @@ var _ = Describe("SessionServiceDecorator", func() {
 			Expect(retrieved.RemediationRef.Name).To(Equal("rr-1"))
 		})
 
-		It("UT-AF-056-PW-010: SessionCreateContextFromContext returns nil when not set", func() {
-			retrieved := session.SessionCreateContextFromContext(ctx)
+		It("UT-AF-056-PW-010: CreateContextFromContext returns nil when not set", func() {
+			retrieved := session.CreateContextFromContext(ctx)
 			Expect(retrieved).To(BeNil())
 		})
 	})

--- a/internal/session/decorator_test.go
+++ b/internal/session/decorator_test.go
@@ -1,0 +1,239 @@
+package session_test
+
+import (
+	"context"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	adksession "google.golang.org/adk/session"
+
+	v1alpha1 "github.com/jordigilh/kubernaut-apifrontend/api/apifrontend/v1alpha1"
+	"github.com/jordigilh/kubernaut-apifrontend/internal/auth"
+	"github.com/jordigilh/kubernaut-apifrontend/internal/session"
+)
+
+var _ = Describe("SessionServiceDecorator", func() {
+	var (
+		inner     adksession.Service
+		decorator *session.SessionServiceDecorator
+		ctx       context.Context
+	)
+
+	BeforeEach(func() {
+		inner = adksession.InMemoryService()
+		decorator = session.NewSessionServiceDecorator(inner)
+		ctx = context.Background()
+	})
+
+	Describe("Create", func() {
+		It("UT-AF-056-PW-001: enriches State with CreateConfig from context", func() {
+			identity := &auth.UserIdentity{Username: "alice", Groups: []string{"sre"}}
+			ctx = auth.WithUserIdentity(ctx, identity)
+			ctx = session.WithSessionCreateContext(ctx, &session.SessionCreateContext{
+				TaskID: "task-123",
+				RemediationRef: v1alpha1.ObjectRef{
+					Namespace: "prod",
+					Name:      "rr-fix-oom",
+				},
+			})
+
+			resp, err := decorator.Create(ctx, &adksession.CreateRequest{
+				AppName: "test-app",
+				UserID:  "alice",
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).NotTo(BeNil())
+			Expect(resp.Session).NotTo(BeNil())
+		})
+
+		It("UT-AF-056-PW-002: passes through unchanged when no context config", func() {
+			resp, err := decorator.Create(ctx, &adksession.CreateRequest{
+				AppName: "test-app",
+				UserID:  "bob",
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).NotTo(BeNil())
+			Expect(resp.Session).NotTo(BeNil())
+		})
+
+		It("UT-AF-056-PW-004: TaskID extracted from context into CreateConfig.A2ATaskID", func() {
+			identity := &auth.UserIdentity{Username: "carol", Groups: []string{"sre"}}
+			ctx = auth.WithUserIdentity(ctx, identity)
+			ctx = session.WithSessionCreateContext(ctx, &session.SessionCreateContext{
+				TaskID: "task-abc-def",
+			})
+
+			// Use the CRDSessionService as inner to verify the CreateConfig is passed through
+			scheme := newScheme()
+			k8s := newFakeClient(scheme)
+			crdSvc := session.NewCRDSessionService(adksession.InMemoryService(), k8s, scheme, "test-ns")
+			dec := session.NewSessionServiceDecorator(crdSvc)
+
+			resp, err := dec.Create(ctx, &adksession.CreateRequest{
+				AppName: "test-app",
+				UserID:  "carol",
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).NotTo(BeNil())
+			Expect(resp.Session).NotTo(BeNil())
+		})
+
+		It("UT-AF-056-PW-005: UserIdentity populated from auth context", func() {
+			identity := &auth.UserIdentity{Username: "dave", Groups: []string{"l1-ops", "sre"}}
+			ctx = auth.WithUserIdentity(ctx, identity)
+			ctx = session.WithSessionCreateContext(ctx, &session.SessionCreateContext{
+				TaskID: "task-user-test",
+			})
+
+			scheme := newScheme()
+			k8s := newFakeClient(scheme)
+			crdSvc := session.NewCRDSessionService(adksession.InMemoryService(), k8s, scheme, "test-ns")
+			dec := session.NewSessionServiceDecorator(crdSvc)
+
+			resp, err := dec.Create(ctx, &adksession.CreateRequest{
+				AppName: "test-app",
+				UserID:  "dave",
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).NotTo(BeNil())
+		})
+
+		It("UT-AF-056-PW-006: concurrent Create calls are safe under -race", func() {
+			identity := &auth.UserIdentity{Username: "eve", Groups: []string{"sre"}}
+			ctx = auth.WithUserIdentity(ctx, identity)
+			ctx = session.WithSessionCreateContext(ctx, &session.SessionCreateContext{
+				TaskID: "task-concurrent",
+			})
+
+			var wg sync.WaitGroup
+			errs := make([]error, 10)
+			for i := range 10 {
+				wg.Add(1)
+				go func(idx int) {
+					defer wg.Done()
+					_, errs[idx] = decorator.Create(ctx, &adksession.CreateRequest{
+						AppName: "test-app",
+						UserID:  "eve",
+					})
+				}(i)
+			}
+			wg.Wait()
+
+			for _, e := range errs {
+				Expect(e).NotTo(HaveOccurred())
+			}
+		})
+
+		It("UT-AF-056-PW-007: non-RFC-1123 TaskID is passed to inner service for sanitization", func() {
+			identity := &auth.UserIdentity{Username: "grace", Groups: []string{"sre"}}
+			ctx = auth.WithUserIdentity(ctx, identity)
+			ctx = session.WithSessionCreateContext(ctx, &session.SessionCreateContext{
+				TaskID: "UPPER-CASE_with/slashes/../traversal",
+			})
+
+			// The decorator passes TaskID through; CRDSessionService sanitizes it
+			scheme := newScheme()
+			k8s := newFakeClient(scheme)
+			crdSvc := session.NewCRDSessionService(adksession.InMemoryService(), k8s, scheme, "test-ns")
+			dec := session.NewSessionServiceDecorator(crdSvc)
+
+			resp, err := dec.Create(ctx, &adksession.CreateRequest{
+				AppName: "test-app",
+				UserID:  "grace",
+			})
+
+			// CRDSessionService handles sanitization internally - should not panic
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).NotTo(BeNil())
+		})
+
+		It("UT-AF-056-PW-008: empty username / nil identity yields error", func() {
+			ctx = session.WithSessionCreateContext(ctx, &session.SessionCreateContext{
+				TaskID: "task-no-identity",
+			})
+
+			_, err := decorator.Create(ctx, &adksession.CreateRequest{
+				AppName: "test-app",
+				UserID:  "ghost",
+			})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("authenticated user identity"))
+		})
+	})
+
+	Describe("Delegation", func() {
+		It("UT-AF-056-PW-003: Get/List/Delete/AppendEvent delegate unchanged", func() {
+			// Create a session first
+			resp, err := decorator.Create(ctx, &adksession.CreateRequest{
+				AppName: "test-app",
+				UserID:  "frank",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			sessionID := resp.Session.ID()
+
+			// Get
+			getResp, err := decorator.Get(ctx, &adksession.GetRequest{
+				AppName:   "test-app",
+				UserID:    "frank",
+				SessionID: sessionID,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(getResp.Session.ID()).To(Equal(sessionID))
+
+			// List
+			listResp, err := decorator.List(ctx, &adksession.ListRequest{
+				AppName: "test-app",
+				UserID:  "frank",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(listResp.Sessions).To(HaveLen(1))
+
+			// Delete
+			err = decorator.Delete(ctx, &adksession.DeleteRequest{
+				AppName:   "test-app",
+				UserID:    "frank",
+				SessionID: sessionID,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify deleted
+			listResp, err = decorator.List(ctx, &adksession.ListRequest{
+				AppName: "test-app",
+				UserID:  "frank",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(listResp.Sessions).To(HaveLen(0))
+		})
+	})
+
+	Describe("Context helpers", func() {
+		It("UT-AF-056-PW-009: WithSessionCreateContext stores and retrieves value", func() {
+			sc := &session.SessionCreateContext{
+				TaskID: "test-task",
+				RemediationRef: v1alpha1.ObjectRef{
+					Namespace: "ns1",
+					Name:      "rr-1",
+				},
+			}
+			enriched := session.WithSessionCreateContext(ctx, sc)
+			retrieved := session.SessionCreateContextFromContext(enriched)
+
+			Expect(retrieved).NotTo(BeNil())
+			Expect(retrieved.TaskID).To(Equal("test-task"))
+			Expect(retrieved.RemediationRef.Namespace).To(Equal("ns1"))
+			Expect(retrieved.RemediationRef.Name).To(Equal("rr-1"))
+		})
+
+		It("UT-AF-056-PW-010: SessionCreateContextFromContext returns nil when not set", func() {
+			retrieved := session.SessionCreateContextFromContext(ctx)
+			Expect(retrieved).To(BeNil())
+		})
+	})
+})

--- a/internal/tools/af_check_existing_rr.go
+++ b/internal/tools/af_check_existing_rr.go
@@ -1,0 +1,77 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+
+	"github.com/jordigilh/kubernaut-apifrontend/internal/validate"
+)
+
+// CheckExistingRRArgs defines the input for af_check_existing_rr.
+type CheckExistingRRArgs struct {
+	Namespace string `json:"namespace"`
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+}
+
+// CheckExistingRRResult is the output of af_check_existing_rr.
+type CheckExistingRRResult struct {
+	Exists bool   `json:"exists"`
+	RRID   string `json:"rr_id,omitempty"`
+	Phase  string `json:"phase,omitempty"`
+}
+
+// HandleCheckExistingRR checks whether a non-terminal RemediationRequest already
+// exists for the given target fingerprint (namespace+kind+name).
+func HandleCheckExistingRR(ctx context.Context, client dynamic.Interface, args CheckExistingRRArgs) (CheckExistingRRResult, error) {
+	if client == nil {
+		return CheckExistingRRResult{}, ErrK8sUnavailable
+	}
+	if err := validate.Namespace(args.Namespace); err != nil {
+		return CheckExistingRRResult{}, fmt.Errorf("%w: %v", ErrInvalidInput, err)
+	}
+	if args.Kind == "" {
+		return CheckExistingRRResult{}, fmt.Errorf("%w: kind must not be empty", ErrInvalidInput)
+	}
+	if args.Name == "" {
+		return CheckExistingRRResult{}, fmt.Errorf("%w: name must not be empty", ErrInvalidInput)
+	}
+
+	labelSel := fmt.Sprintf("kubernaut.ai/target-kind=%s,kubernaut.ai/target-name=%s", args.Kind, args.Name)
+	list, err := client.Resource(rrGVR).Namespace(args.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSel,
+	})
+	if err != nil {
+		return CheckExistingRRResult{}, ToUserFriendlyError(err)
+	}
+
+	for _, item := range list.Items {
+		phase, _, _ := unstructured.NestedString(item.Object, "status", "phase")
+		if !IsTerminalPhase(phase) {
+			return CheckExistingRRResult{
+				Exists: true,
+				RRID:   item.GetNamespace() + "/" + item.GetName(),
+				Phase:  phase,
+			}, nil
+		}
+	}
+
+	return CheckExistingRRResult{Exists: false}, nil
+}
+
+// NewCheckExistingRRTool creates the af_check_existing_rr tool.
+func NewCheckExistingRRTool(client dynamic.Interface) (tool.Tool, error) {
+	return functiontool.New(functiontool.Config{
+		Name:        "af_check_existing_rr",
+		Description: "Check if a non-terminal RemediationRequest already exists for a target resource (deduplication check)",
+	}, func(ctx tool.Context, args CheckExistingRRArgs) (CheckExistingRRResult, error) {
+		return HandleCheckExistingRR(ctx, client, args)
+	})
+}

--- a/internal/tools/af_check_existing_rr.go
+++ b/internal/tools/af_check_existing_rr.go
@@ -40,8 +40,14 @@ func HandleCheckExistingRR(ctx context.Context, client dynamic.Interface, args C
 	if args.Kind == "" {
 		return CheckExistingRRResult{}, fmt.Errorf("%w: kind must not be empty", ErrInvalidInput)
 	}
+	if err := validate.LabelValue(args.Kind); err != nil {
+		return CheckExistingRRResult{}, fmt.Errorf("%w: %v", ErrInvalidInput, err)
+	}
 	if args.Name == "" {
 		return CheckExistingRRResult{}, fmt.Errorf("%w: name must not be empty", ErrInvalidInput)
+	}
+	if err := validate.LabelValue(args.Name); err != nil {
+		return CheckExistingRRResult{}, fmt.Errorf("%w: %v", ErrInvalidInput, err)
 	}
 
 	labelSel := fmt.Sprintf("kubernaut.ai/target-kind=%s,kubernaut.ai/target-name=%s", args.Kind, args.Name)

--- a/internal/tools/af_check_existing_rr_test.go
+++ b/internal/tools/af_check_existing_rr_test.go
@@ -1,0 +1,143 @@
+package tools_test
+
+import (
+	"context"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/jordigilh/kubernaut-apifrontend/internal/tools"
+)
+
+func newUnstructuredRR(ns, name, phase, targetKind, targetName string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "kubernaut.ai/v1alpha1",
+			"kind":       "RemediationRequest",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": ns,
+				"labels": map[string]interface{}{
+					"kubernaut.ai/target-kind": targetKind,
+					"kubernaut.ai/target-name": targetName,
+				},
+			},
+			"status": map[string]interface{}{
+				"phase": phase,
+			},
+		},
+	}
+}
+
+var _ = Describe("af_check_existing_rr", func() {
+	rrGVR := schema.GroupVersionResource{Group: "kubernaut.ai", Version: "v1alpha1", Resource: "remediationrequests"}
+
+	It("UT-AF-052-040: finds active RR for matching fingerprint", func() {
+		rr := newUnstructuredRR("prod", "rr-deploy-web-1", "Executing", "Deployment", "web")
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"},
+			rr,
+		)
+
+		result, err := tools.HandleCheckExistingRR(context.Background(), client, tools.CheckExistingRRArgs{
+			Namespace: "prod", Kind: "Deployment", Name: "web",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Exists).To(BeTrue())
+		Expect(result.RRID).To(Equal("prod/rr-deploy-web-1"))
+		Expect(result.Phase).To(Equal("Executing"))
+	})
+
+	It("UT-AF-052-041: terminal RR not reported as existing", func() {
+		rr := newUnstructuredRR("prod", "rr-deploy-web-1", "Completed", "Deployment", "web")
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"},
+			rr,
+		)
+
+		result, err := tools.HandleCheckExistingRR(context.Background(), client, tools.CheckExistingRRArgs{
+			Namespace: "prod", Kind: "Deployment", Name: "web",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Exists).To(BeFalse())
+	})
+
+	It("UT-AF-052-042: no RRs at all returns exists=false", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
+
+		result, err := tools.HandleCheckExistingRR(context.Background(), client, tools.CheckExistingRRArgs{
+			Namespace: "prod", Kind: "Deployment", Name: "web",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Exists).To(BeFalse())
+	})
+
+	It("UT-AF-052-043: empty namespace rejected", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
+
+		_, err := tools.HandleCheckExistingRR(context.Background(), client, tools.CheckExistingRRArgs{
+			Namespace: "", Kind: "Deployment", Name: "web",
+		})
+		Expect(err).To(MatchError(ContainSubstring("invalid input")))
+	})
+
+	It("UT-AF-052-044: empty kind rejected", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
+
+		_, err := tools.HandleCheckExistingRR(context.Background(), client, tools.CheckExistingRRArgs{
+			Namespace: "prod", Kind: "", Name: "web",
+		})
+		Expect(err).To(MatchError(ContainSubstring("invalid input")))
+	})
+
+	It("UT-AF-052-045: empty name rejected", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
+
+		_, err := tools.HandleCheckExistingRR(context.Background(), client, tools.CheckExistingRRArgs{
+			Namespace: "prod", Kind: "Deployment", Name: "",
+		})
+		Expect(err).To(MatchError(ContainSubstring("invalid input")))
+	})
+
+	It("UT-AF-052-046: nil client returns ErrK8sUnavailable", func() {
+		_, err := tools.HandleCheckExistingRR(context.Background(), nil, tools.CheckExistingRRArgs{
+			Namespace: "prod", Kind: "Deployment", Name: "web",
+		})
+		Expect(err).To(MatchError(tools.ErrK8sUnavailable))
+	})
+
+	It("UT-AF-052-047: concurrent calls safe", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
+
+		var wg sync.WaitGroup
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, err := tools.HandleCheckExistingRR(context.Background(), client, tools.CheckExistingRRArgs{
+					Namespace: "prod", Kind: "Deployment", Name: "web",
+				})
+				Expect(err).NotTo(HaveOccurred())
+			}()
+		}
+		wg.Wait()
+	})
+})

--- a/internal/tools/af_check_existing_rr_test.go
+++ b/internal/tools/af_check_existing_rr_test.go
@@ -2,6 +2,7 @@ package tools_test
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -139,5 +140,27 @@ var _ = Describe("af_check_existing_rr", func() {
 			}()
 		}
 		wg.Wait()
+	})
+
+	It("UT-AF-052-048: kind with invalid label characters rejected", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
+
+		_, err := tools.HandleCheckExistingRR(context.Background(), client, tools.CheckExistingRRArgs{
+			Namespace: "prod", Kind: "ns/Deployment", Name: "web",
+		})
+		Expect(err).To(MatchError(ContainSubstring("invalid input")))
+	})
+
+	It("UT-AF-052-049: name with invalid label characters rejected", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
+
+		_, err := tools.HandleCheckExistingRR(context.Background(), client, tools.CheckExistingRRArgs{
+			Namespace: "prod", Kind: "Deployment", Name: strings.Repeat("a", 64),
+		})
+		Expect(err).To(MatchError(ContainSubstring("invalid input")))
 	})
 })

--- a/internal/tools/af_create_rr.go
+++ b/internal/tools/af_create_rr.go
@@ -46,7 +46,7 @@ func rrFingerprint(namespace, kind, name string) string {
 
 // HandleCreateRR creates a RemediationRequest CRD with singleflight deduplication.
 // Concurrent calls with the same fingerprint are deduplicated — only one creation executes.
-func HandleCreateRR(ctx context.Context, client dynamic.Interface, args CreateRRArgs, username string) (CreateRRResult, error) {
+func HandleCreateRR(ctx context.Context, client dynamic.Interface, args *CreateRRArgs, username string) (CreateRRResult, error) {
 	if client == nil {
 		return CreateRRResult{}, ErrK8sUnavailable
 	}
@@ -128,7 +128,11 @@ func HandleCreateRR(ctx context.Context, client dynamic.Interface, args CreateRR
 	if err != nil {
 		return CreateRRResult{}, err
 	}
-	return *result.(*CreateRRResult), nil
+	res, ok := result.(*CreateRRResult)
+	if !ok {
+		return CreateRRResult{}, fmt.Errorf("unexpected singleflight result type")
+	}
+	return *res, nil
 }
 
 // NewCreateRRTool creates the af_create_rr tool.
@@ -137,6 +141,6 @@ func NewCreateRRTool(client dynamic.Interface) (tool.Tool, error) {
 		Name:        "af_create_rr",
 		Description: "Create a RemediationRequest for a target resource with deduplication. Checks for existing non-terminal RRs before creating.",
 	}, func(ctx tool.Context, args CreateRRArgs) (CreateRRResult, error) {
-		return HandleCreateRR(ctx, client, args, usernameFromContext(ctx))
+		return HandleCreateRR(ctx, client, &args, usernameFromContext(ctx))
 	})
 }

--- a/internal/tools/af_create_rr.go
+++ b/internal/tools/af_create_rr.go
@@ -20,6 +20,15 @@ import (
 // maxDescriptionLen is the maximum length for RR description (truncated, not rejected).
 const maxDescriptionLen = 2048
 
+// validSeverities is the allowlist of accepted severity values for RemediationRequests.
+var validSeverities = map[string]bool{
+	"critical": true,
+	"high":     true,
+	"medium":   true,
+	"low":      true,
+	"info":     true,
+}
+
 // CreateRRArgs defines the input for af_create_rr.
 type CreateRRArgs struct {
 	Namespace   string `json:"namespace"`
@@ -37,6 +46,11 @@ type CreateRRResult struct {
 }
 
 // rrCreateGroup provides singleflight deduplication per fingerprint.
+// Dedup is intentionally user-agnostic: concurrent RR creation for the same
+// target resource is deduplicated regardless of which user initiated it.
+// This is acceptable because RR ownership is tracked via labels (reported-by),
+// and the check_existing_rr safety net prevents duplicate CRDs regardless.
+// Note: parallel tests with the same fingerprint may share flights (by design).
 var rrCreateGroup singleflight.Group
 
 func rrFingerprint(namespace, kind, name string) string {
@@ -58,6 +72,9 @@ func HandleCreateRR(ctx context.Context, client dynamic.Interface, args *CreateR
 	}
 	if args.Name == "" {
 		return CreateRRResult{}, fmt.Errorf("%w: name must not be empty", ErrInvalidInput)
+	}
+	if args.Severity != "" && !validSeverities[args.Severity] {
+		return CreateRRResult{}, fmt.Errorf("%w: severity must be one of critical, high, medium, low, info", ErrInvalidInput)
 	}
 
 	if len(args.Description) > maxDescriptionLen {

--- a/internal/tools/af_create_rr.go
+++ b/internal/tools/af_create_rr.go
@@ -1,0 +1,142 @@
+package tools
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+
+	"github.com/jordigilh/kubernaut-apifrontend/internal/validate"
+)
+
+// maxDescriptionLen is the maximum length for RR description (truncated, not rejected).
+const maxDescriptionLen = 2048
+
+// CreateRRArgs defines the input for af_create_rr.
+type CreateRRArgs struct {
+	Namespace   string `json:"namespace"`
+	Kind        string `json:"kind"`
+	Name        string `json:"name"`
+	Severity    string `json:"severity,omitempty"`
+	Description string `json:"description"`
+}
+
+// CreateRRResult is the output of af_create_rr.
+type CreateRRResult struct {
+	RRID          string `json:"rr_id"`
+	Message       string `json:"message"`
+	AlreadyExists bool   `json:"already_exists,omitempty"`
+}
+
+// rrCreateGroup provides singleflight deduplication per fingerprint.
+var rrCreateGroup singleflight.Group
+
+func rrFingerprint(namespace, kind, name string) string {
+	h := sha256.Sum256([]byte(namespace + "/" + kind + "/" + name))
+	return fmt.Sprintf("%x", h[:16])
+}
+
+// HandleCreateRR creates a RemediationRequest CRD with singleflight deduplication.
+// Concurrent calls with the same fingerprint are deduplicated — only one creation executes.
+func HandleCreateRR(ctx context.Context, client dynamic.Interface, args CreateRRArgs, username string) (CreateRRResult, error) {
+	if client == nil {
+		return CreateRRResult{}, ErrK8sUnavailable
+	}
+	if err := validate.Namespace(args.Namespace); err != nil {
+		return CreateRRResult{}, fmt.Errorf("%w: %v", ErrInvalidInput, err)
+	}
+	if args.Kind == "" {
+		return CreateRRResult{}, fmt.Errorf("%w: kind must not be empty", ErrInvalidInput)
+	}
+	if args.Name == "" {
+		return CreateRRResult{}, fmt.Errorf("%w: name must not be empty", ErrInvalidInput)
+	}
+
+	if len(args.Description) > maxDescriptionLen {
+		args.Description = args.Description[:maxDescriptionLen]
+	}
+
+	fingerprint := rrFingerprint(args.Namespace, args.Kind, args.Name)
+
+	result, err, _ := rrCreateGroup.Do(fingerprint, func() (interface{}, error) {
+		existing, checkErr := HandleCheckExistingRR(ctx, client, CheckExistingRRArgs{
+			Namespace: args.Namespace,
+			Kind:      args.Kind,
+			Name:      args.Name,
+		})
+		if checkErr != nil {
+			return nil, checkErr
+		}
+		if existing.Exists {
+			return &CreateRRResult{
+				RRID:          existing.RRID,
+				Message:       fmt.Sprintf("RemediationRequest already exists (%s)", existing.Phase),
+				AlreadyExists: true,
+			}, nil
+		}
+
+		rrName := fmt.Sprintf("rr-%s-%s-%d", args.Kind, args.Name, time.Now().UnixMilli())
+		if len(rrName) > 63 {
+			rrName = rrName[:63]
+		}
+
+		rr := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "kubernaut.ai/v1alpha1",
+				"kind":       "RemediationRequest",
+				"metadata": map[string]interface{}{
+					"name":      rrName,
+					"namespace": args.Namespace,
+					"labels": map[string]interface{}{
+						"kubernaut.ai/target-kind": args.Kind,
+						"kubernaut.ai/target-name": args.Name,
+						"kubernaut.ai/reported-by": username,
+					},
+				},
+				"spec": map[string]interface{}{
+					"targetRef": map[string]interface{}{
+						"kind":      args.Kind,
+						"name":      args.Name,
+						"namespace": args.Namespace,
+					},
+					"severity":    args.Severity,
+					"description": args.Description,
+					"reportedBy":  username,
+				},
+			},
+		}
+
+		created, createErr := client.Resource(rrGVR).Namespace(args.Namespace).Create(ctx, rr, metav1.CreateOptions{})
+		if createErr != nil {
+			return nil, ToUserFriendlyError(createErr)
+		}
+
+		return &CreateRRResult{
+			RRID:    created.GetNamespace() + "/" + created.GetName(),
+			Message: fmt.Sprintf("RemediationRequest created for %s/%s by %s", args.Kind, args.Name, username),
+		}, nil
+	})
+
+	if err != nil {
+		return CreateRRResult{}, err
+	}
+	return *result.(*CreateRRResult), nil
+}
+
+// NewCreateRRTool creates the af_create_rr tool.
+func NewCreateRRTool(client dynamic.Interface) (tool.Tool, error) {
+	return functiontool.New(functiontool.Config{
+		Name:        "af_create_rr",
+		Description: "Create a RemediationRequest for a target resource with deduplication. Checks for existing non-terminal RRs before creating.",
+	}, func(ctx tool.Context, args CreateRRArgs) (CreateRRResult, error) {
+		return HandleCreateRR(ctx, client, args, usernameFromContext(ctx))
+	})
+}

--- a/internal/tools/af_create_rr_test.go
+++ b/internal/tools/af_create_rr_test.go
@@ -1,0 +1,160 @@
+package tools_test
+
+import (
+	"context"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/jordigilh/kubernaut-apifrontend/internal/tools"
+)
+
+var _ = Describe("af_create_rr", func() {
+	rrGVR := schema.GroupVersionResource{Group: "kubernaut.ai", Version: "v1alpha1", Resource: "remediationrequests"}
+
+	It("UT-AF-052-050: creates RR when none exists", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
+
+		result, err := tools.HandleCreateRR(context.Background(), client, tools.CreateRRArgs{
+			Namespace:   "prod",
+			Kind:        "Deployment",
+			Name:        "web",
+			Severity:    "high",
+			Description: "Pod CrashLoopBackOff detected",
+		}, "sre-user")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RRID).NotTo(BeEmpty())
+		Expect(result.AlreadyExists).To(BeFalse())
+		Expect(result.Message).To(ContainSubstring("created"))
+	})
+
+	It("UT-AF-052-051: returns existing RR when non-terminal match found", func() {
+		rr := newUnstructuredRR("prod", "rr-deploy-web-existing", "Executing", "Deployment", "web")
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"},
+			rr,
+		)
+
+		result, err := tools.HandleCreateRR(context.Background(), client, tools.CreateRRArgs{
+			Namespace:   "prod",
+			Kind:        "Deployment",
+			Name:        "web",
+			Description: "duplicate",
+		}, "sre-user")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.AlreadyExists).To(BeTrue())
+		Expect(result.RRID).To(Equal("prod/rr-deploy-web-existing"))
+	})
+
+	It("UT-AF-052-052: empty namespace rejected", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
+
+		_, err := tools.HandleCreateRR(context.Background(), client, tools.CreateRRArgs{
+			Namespace: "", Kind: "Deployment", Name: "web", Description: "x",
+		}, "user")
+		Expect(err).To(MatchError(ContainSubstring("invalid input")))
+	})
+
+	It("UT-AF-052-053: empty kind rejected", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
+
+		_, err := tools.HandleCreateRR(context.Background(), client, tools.CreateRRArgs{
+			Namespace: "prod", Kind: "", Name: "web", Description: "x",
+		}, "user")
+		Expect(err).To(MatchError(ContainSubstring("invalid input")))
+	})
+
+	It("UT-AF-052-054: empty name rejected", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
+
+		_, err := tools.HandleCreateRR(context.Background(), client, tools.CreateRRArgs{
+			Namespace: "prod", Kind: "Deployment", Name: "", Description: "x",
+		}, "user")
+		Expect(err).To(MatchError(ContainSubstring("invalid input")))
+	})
+
+	It("UT-AF-052-055: nil client returns ErrK8sUnavailable", func() {
+		_, err := tools.HandleCreateRR(context.Background(), nil, tools.CreateRRArgs{
+			Namespace: "prod", Kind: "Deployment", Name: "web", Description: "x",
+		}, "user")
+		Expect(err).To(MatchError(tools.ErrK8sUnavailable))
+	})
+
+	It("UT-AF-052-056: long description is truncated not rejected", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
+
+		longDesc := make([]byte, 4096)
+		for i := range longDesc {
+			longDesc[i] = 'a'
+		}
+
+		result, err := tools.HandleCreateRR(context.Background(), client, tools.CreateRRArgs{
+			Namespace:   "prod",
+			Kind:        "Deployment",
+			Name:        "web",
+			Description: string(longDesc),
+		}, "user")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RRID).NotTo(BeEmpty())
+	})
+
+	It("UT-AF-052-057: concurrent calls with same fingerprint are deduplicated", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
+
+		var wg sync.WaitGroup
+		results := make([]tools.CreateRRResult, 5)
+		errs := make([]error, 5)
+
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				results[idx], errs[idx] = tools.HandleCreateRR(context.Background(), client, tools.CreateRRArgs{
+					Namespace:   "prod",
+					Kind:        "Deployment",
+					Name:        "dedup-target",
+					Description: "concurrent test",
+				}, "user")
+			}(i)
+		}
+		wg.Wait()
+
+		for _, err := range errs {
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		firstRRID := results[0].RRID
+		for _, r := range results[1:] {
+			Expect(r.RRID).To(Equal(firstRRID))
+		}
+	})
+
+	It("UT-AF-052-058: invalid namespace (path traversal) rejected", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
+
+		_, err := tools.HandleCreateRR(context.Background(), client, tools.CreateRRArgs{
+			Namespace: "../../etc", Kind: "Deployment", Name: "web", Description: "x",
+		}, "user")
+		Expect(err).To(MatchError(ContainSubstring("invalid input")))
+	})
+})

--- a/internal/tools/af_create_rr_test.go
+++ b/internal/tools/af_create_rr_test.go
@@ -157,4 +157,51 @@ var _ = Describe("af_create_rr", func() {
 		}, "user")
 		Expect(err).To(MatchError(ContainSubstring("invalid input")))
 	})
+
+	It("UT-AF-052-059: invalid severity rejected", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
+
+		_, err := tools.HandleCreateRR(context.Background(), client, &tools.CreateRRArgs{
+			Namespace:   "prod",
+			Kind:        "Deployment",
+			Name:        "web",
+			Severity:    "CATASTROPHIC",
+			Description: "bad sev",
+		}, "user")
+		Expect(err).To(MatchError(ContainSubstring("severity must be one of")))
+	})
+
+	It("UT-AF-052-060: valid severity accepted", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
+
+		result, err := tools.HandleCreateRR(context.Background(), client, &tools.CreateRRArgs{
+			Namespace:   "prod",
+			Kind:        "Deployment",
+			Name:        "web",
+			Severity:    "critical",
+			Description: "oom kill",
+		}, "alice")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RRID).NotTo(BeEmpty())
+	})
+
+	It("UT-AF-052-061: empty severity accepted (optional field)", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
+
+		result, err := tools.HandleCreateRR(context.Background(), client, &tools.CreateRRArgs{
+			Namespace:   "prod",
+			Kind:        "Deployment",
+			Name:        "web",
+			Severity:    "",
+			Description: "no sev",
+		}, "alice")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RRID).NotTo(BeEmpty())
+	})
 })

--- a/internal/tools/af_create_rr_test.go
+++ b/internal/tools/af_create_rr_test.go
@@ -22,7 +22,7 @@ var _ = Describe("af_create_rr", func() {
 		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
 			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
 
-		result, err := tools.HandleCreateRR(context.Background(), client, tools.CreateRRArgs{
+		result, err := tools.HandleCreateRR(context.Background(), client, &tools.CreateRRArgs{
 			Namespace:   "prod",
 			Kind:        "Deployment",
 			Name:        "web",
@@ -43,7 +43,7 @@ var _ = Describe("af_create_rr", func() {
 			rr,
 		)
 
-		result, err := tools.HandleCreateRR(context.Background(), client, tools.CreateRRArgs{
+		result, err := tools.HandleCreateRR(context.Background(), client, &tools.CreateRRArgs{
 			Namespace:   "prod",
 			Kind:        "Deployment",
 			Name:        "web",
@@ -59,7 +59,7 @@ var _ = Describe("af_create_rr", func() {
 		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
 			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
 
-		_, err := tools.HandleCreateRR(context.Background(), client, tools.CreateRRArgs{
+		_, err := tools.HandleCreateRR(context.Background(), client, &tools.CreateRRArgs{
 			Namespace: "", Kind: "Deployment", Name: "web", Description: "x",
 		}, "user")
 		Expect(err).To(MatchError(ContainSubstring("invalid input")))
@@ -70,7 +70,7 @@ var _ = Describe("af_create_rr", func() {
 		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
 			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
 
-		_, err := tools.HandleCreateRR(context.Background(), client, tools.CreateRRArgs{
+		_, err := tools.HandleCreateRR(context.Background(), client, &tools.CreateRRArgs{
 			Namespace: "prod", Kind: "", Name: "web", Description: "x",
 		}, "user")
 		Expect(err).To(MatchError(ContainSubstring("invalid input")))
@@ -81,14 +81,14 @@ var _ = Describe("af_create_rr", func() {
 		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
 			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
 
-		_, err := tools.HandleCreateRR(context.Background(), client, tools.CreateRRArgs{
+		_, err := tools.HandleCreateRR(context.Background(), client, &tools.CreateRRArgs{
 			Namespace: "prod", Kind: "Deployment", Name: "", Description: "x",
 		}, "user")
 		Expect(err).To(MatchError(ContainSubstring("invalid input")))
 	})
 
 	It("UT-AF-052-055: nil client returns ErrK8sUnavailable", func() {
-		_, err := tools.HandleCreateRR(context.Background(), nil, tools.CreateRRArgs{
+		_, err := tools.HandleCreateRR(context.Background(), nil, &tools.CreateRRArgs{
 			Namespace: "prod", Kind: "Deployment", Name: "web", Description: "x",
 		}, "user")
 		Expect(err).To(MatchError(tools.ErrK8sUnavailable))
@@ -104,7 +104,7 @@ var _ = Describe("af_create_rr", func() {
 			longDesc[i] = 'a'
 		}
 
-		result, err := tools.HandleCreateRR(context.Background(), client, tools.CreateRRArgs{
+		result, err := tools.HandleCreateRR(context.Background(), client, &tools.CreateRRArgs{
 			Namespace:   "prod",
 			Kind:        "Deployment",
 			Name:        "web",
@@ -127,7 +127,7 @@ var _ = Describe("af_create_rr", func() {
 			wg.Add(1)
 			go func(idx int) {
 				defer wg.Done()
-				results[idx], errs[idx] = tools.HandleCreateRR(context.Background(), client, tools.CreateRRArgs{
+				results[idx], errs[idx] = tools.HandleCreateRR(context.Background(), client, &tools.CreateRRArgs{
 					Namespace:   "prod",
 					Kind:        "Deployment",
 					Name:        "dedup-target",
@@ -152,7 +152,7 @@ var _ = Describe("af_create_rr", func() {
 		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
 			map[schema.GroupVersionResource]string{rrGVR: "RemediationRequestList"})
 
-		_, err := tools.HandleCreateRR(context.Background(), client, tools.CreateRRArgs{
+		_, err := tools.HandleCreateRR(context.Background(), client, &tools.CreateRRArgs{
 			Namespace: "../../etc", Kind: "Deployment", Name: "web", Description: "x",
 		}, "user")
 		Expect(err).To(MatchError(ContainSubstring("invalid input")))

--- a/internal/tools/af_get_pods.go
+++ b/internal/tools/af_get_pods.go
@@ -1,0 +1,183 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+
+	"github.com/jordigilh/kubernaut-apifrontend/internal/auth"
+	"github.com/jordigilh/kubernaut-apifrontend/internal/validate"
+)
+
+// GetPodsArgs defines the input for af_get_pods.
+type GetPodsArgs struct {
+	Namespace     string `json:"namespace"`
+	LabelSelector string `json:"label_selector,omitempty"`
+}
+
+// ContainerStatus is a compact view of a container's state.
+type ContainerStatus struct {
+	Name     string `json:"name"`
+	Ready    bool   `json:"ready"`
+	State    string `json:"state"`
+	Reason   string `json:"reason,omitempty"`
+	Restarts int64  `json:"restarts"`
+}
+
+// PodSummary is a compact view of a Pod's status.
+type PodSummary struct {
+	Name       string            `json:"name"`
+	Phase      string            `json:"phase"`
+	Conditions []string          `json:"conditions,omitempty"`
+	Containers []ContainerStatus `json:"containers"`
+	NodeName   string            `json:"node_name,omitempty"`
+}
+
+// GetPodsResult is the output of af_get_pods.
+type GetPodsResult struct {
+	Pods      []PodSummary `json:"pods"`
+	Count     int          `json:"count"`
+	Truncated bool         `json:"truncated,omitempty"`
+}
+
+var podsGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+
+// HandleGetPods implements the af_get_pods logic.
+func HandleGetPods(ctx context.Context, client dynamic.Interface, args GetPodsArgs) (GetPodsResult, error) {
+	if client == nil {
+		return GetPodsResult{}, ErrK8sUnavailable
+	}
+	if err := validate.Namespace(args.Namespace); err != nil {
+		return GetPodsResult{}, fmt.Errorf("%w: %v", ErrInvalidInput, err)
+	}
+
+	opts := metav1.ListOptions{}
+	if args.LabelSelector != "" {
+		opts.LabelSelector = args.LabelSelector
+	}
+
+	list, err := client.Resource(podsGVR).Namespace(args.Namespace).List(ctx, opts)
+	if err != nil {
+		return GetPodsResult{}, ToUserFriendlyError(err)
+	}
+
+	result := make([]PodSummary, 0, len(list.Items))
+	for i := range list.Items {
+		item := &list.Items[i]
+		phase, _, _ := unstructured.NestedString(item.Object, "status", "phase")
+		nodeName, _, _ := unstructured.NestedString(item.Object, "spec", "nodeName")
+
+		containers := extractContainerStatuses(item.Object)
+		conditions := extractTrueConditions(item.Object)
+
+		result = append(result, PodSummary{
+			Name:       item.GetName(),
+			Phase:      phase,
+			Conditions: conditions,
+			Containers: containers,
+			NodeName:   nodeName,
+		})
+	}
+
+	result, truncated := TrimSliceToFit(result)
+
+	return GetPodsResult{
+		Pods:      result,
+		Count:     len(result),
+		Truncated: truncated,
+	}, nil
+}
+
+func extractContainerStatuses(obj map[string]interface{}) []ContainerStatus {
+	statuses, found, _ := unstructured.NestedSlice(obj, "status", "containerStatuses")
+	if !found {
+		return nil
+	}
+	result := make([]ContainerStatus, 0, len(statuses))
+	for _, s := range statuses {
+		cs, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _, _ := unstructured.NestedString(cs, "name")
+		ready, _, _ := unstructured.NestedBool(cs, "ready")
+		restarts, _, _ := unstructured.NestedInt64(cs, "restartCount")
+		state, reason := parseContainerState(cs)
+
+		result = append(result, ContainerStatus{
+			Name:     name,
+			Ready:    ready,
+			State:    state,
+			Reason:   reason,
+			Restarts: restarts,
+		})
+	}
+	return result
+}
+
+func parseContainerState(cs map[string]interface{}) (string, string) {
+	stateMap, found, _ := unstructured.NestedMap(cs, "state")
+	if !found {
+		return "unknown", ""
+	}
+	if _, ok := stateMap["running"]; ok {
+		return "running", ""
+	}
+	if waiting, ok := stateMap["waiting"]; ok {
+		if w, ok := waiting.(map[string]interface{}); ok {
+			reason, _, _ := unstructured.NestedString(w, "reason")
+			return "waiting", reason
+		}
+		return "waiting", ""
+	}
+	if terminated, ok := stateMap["terminated"]; ok {
+		if t, ok := terminated.(map[string]interface{}); ok {
+			reason, _, _ := unstructured.NestedString(t, "reason")
+			return "terminated", reason
+		}
+		return "terminated", ""
+	}
+	return "unknown", ""
+}
+
+func extractTrueConditions(obj map[string]interface{}) []string {
+	conditions, found, _ := unstructured.NestedSlice(obj, "status", "conditions")
+	if !found {
+		return nil
+	}
+	var result []string
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		status, _, _ := unstructured.NestedString(cond, "status")
+		if status == "True" {
+			condType, _, _ := unstructured.NestedString(cond, "type")
+			result = append(result, condType)
+		}
+	}
+	return result
+}
+
+// NewGetPodsTool creates the af_get_pods tool.
+// Uses DynamicClientFactory to obtain a per-request impersonated client (SEC-05).
+func NewGetPodsTool(factory auth.DynamicClientFactory) (tool.Tool, error) {
+	return functiontool.New(functiontool.Config{
+		Name:        "af_get_pods",
+		Description: "Get pod status summaries with container states in a namespace, optionally filtered by label selector",
+	}, func(ctx tool.Context, args GetPodsArgs) (GetPodsResult, error) {
+		client, err := factory(ctx)
+		if err != nil {
+			return GetPodsResult{}, fmt.Errorf("%w", ErrK8sUnavailable)
+		}
+		return HandleGetPods(ctx, client, args)
+	})
+}

--- a/internal/tools/af_get_pods.go
+++ b/internal/tools/af_get_pods.go
@@ -122,7 +122,7 @@ func extractContainerStatuses(obj map[string]interface{}) []ContainerStatus {
 	return result
 }
 
-func parseContainerState(cs map[string]interface{}) (state string, reason string) {
+func parseContainerState(cs map[string]interface{}) (state, reason string) {
 	stateMap, found, _ := unstructured.NestedMap(cs, "state")
 	if !found {
 		return "unknown", ""

--- a/internal/tools/af_get_pods.go
+++ b/internal/tools/af_get_pods.go
@@ -122,7 +122,7 @@ func extractContainerStatuses(obj map[string]interface{}) []ContainerStatus {
 	return result
 }
 
-func parseContainerState(cs map[string]interface{}) (string, string) {
+func parseContainerState(cs map[string]interface{}) (state string, reason string) {
 	stateMap, found, _ := unstructured.NestedMap(cs, "state")
 	if !found {
 		return "unknown", ""

--- a/internal/tools/af_get_pods_test.go
+++ b/internal/tools/af_get_pods_test.go
@@ -1,0 +1,172 @@
+package tools_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/jordigilh/kubernaut-apifrontend/internal/tools"
+)
+
+var podsGVRTest = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+
+var _ = Describe("af_get_pods", func() {
+	var (
+		ctx    context.Context
+		scheme *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+	})
+
+	It("UT-AF-052-010: returns pod summaries with container states", func() {
+		pod := newUnstructuredPodObj("prod", "my-pod", "Running", []interface{}{
+			map[string]interface{}{"name": "app", "ready": true, "state": map[string]interface{}{"running": map[string]interface{}{}}, "restartCount": int64(0)},
+			map[string]interface{}{"name": "sidecar", "ready": false, "state": map[string]interface{}{"waiting": map[string]interface{}{"reason": "CrashLoopBackOff"}}, "restartCount": int64(5)},
+		})
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{podsGVRTest: "PodList"}, pod)
+
+		result, err := tools.HandleGetPods(ctx, client, tools.GetPodsArgs{Namespace: "prod"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Count).To(Equal(1))
+		Expect(result.Pods[0].Name).To(Equal("my-pod"))
+		Expect(result.Pods[0].Phase).To(Equal("Running"))
+		Expect(result.Pods[0].Containers).To(HaveLen(2))
+		Expect(result.Pods[0].Containers[0].State).To(Equal("running"))
+		Expect(result.Pods[0].Containers[1].State).To(Equal("waiting"))
+		Expect(result.Pods[0].Containers[1].Reason).To(Equal("CrashLoopBackOff"))
+		Expect(result.Pods[0].Containers[1].Restarts).To(Equal(int64(5)))
+	})
+
+	It("UT-AF-052-011: empty namespace rejected", func() {
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{podsGVRTest: "PodList"})
+		_, err := tools.HandleGetPods(ctx, client, tools.GetPodsArgs{Namespace: ""})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid input"))
+	})
+
+	It("UT-AF-052-012: unicode namespace rejected", func() {
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{podsGVRTest: "PodList"})
+		_, err := tools.HandleGetPods(ctx, client, tools.GetPodsArgs{Namespace: "名前空間"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid input"))
+	})
+
+	It("UT-AF-052-013: max-length+1 namespace rejected", func() {
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{podsGVRTest: "PodList"})
+		longNS := strings.Repeat("a", 64)
+		_, err := tools.HandleGetPods(ctx, client, tools.GetPodsArgs{Namespace: longNS})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid input"))
+	})
+
+	It("UT-AF-052-014: large result is trimmed", func() {
+		var objs []runtime.Object
+		for i := range 100 {
+			pod := newUnstructuredPodObj("prod", fmt.Sprintf("pod-%s-%d", strings.Repeat("x", 30), i), "Running", []interface{}{
+				map[string]interface{}{"name": "c1", "ready": true, "state": map[string]interface{}{"running": map[string]interface{}{}}, "restartCount": int64(0)},
+				map[string]interface{}{"name": "c2", "ready": true, "state": map[string]interface{}{"running": map[string]interface{}{}}, "restartCount": int64(0)},
+			})
+			objs = append(objs, pod)
+		}
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{podsGVRTest: "PodList"}, objs...)
+
+		result, err := tools.HandleGetPods(ctx, client, tools.GetPodsArgs{Namespace: "prod"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Truncated).To(BeTrue())
+		Expect(result.Count).To(BeNumerically("<", 100))
+	})
+
+	It("UT-AF-052-015: nil client returns ErrK8sUnavailable", func() {
+		_, err := tools.HandleGetPods(ctx, nil, tools.GetPodsArgs{Namespace: "prod"})
+		Expect(err).To(MatchError(tools.ErrK8sUnavailable))
+	})
+
+	It("UT-AF-052-016: concurrent calls safe", func() {
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{podsGVRTest: "PodList"})
+		var wg sync.WaitGroup
+		errs := make([]error, 10)
+		for i := range 10 {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				_, errs[idx] = tools.HandleGetPods(ctx, client, tools.GetPodsArgs{Namespace: "prod"})
+			}(i)
+		}
+		wg.Wait()
+		for _, e := range errs {
+			Expect(e).NotTo(HaveOccurred())
+		}
+	})
+
+	It("UT-AF-052-017: passes label selector to API call", func() {
+		// Pods with matching labels set in metadata
+		pod1 := &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "web-1",
+				"namespace": "prod",
+				"labels":    map[string]interface{}{"app": "web"},
+			},
+			"status": map[string]interface{}{"phase": "Running"},
+		}}
+		pod2 := &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "worker-1",
+				"namespace": "prod",
+				"labels":    map[string]interface{}{"app": "worker"},
+			},
+			"status": map[string]interface{}{"phase": "Running"},
+		}}
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{podsGVRTest: "PodList"}, pod1, pod2)
+
+		result, err := tools.HandleGetPods(ctx, client, tools.GetPodsArgs{
+			Namespace:     "prod",
+			LabelSelector: "app=web",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Count).To(Equal(1))
+		Expect(result.Pods[0].Name).To(Equal("web-1"))
+	})
+})
+
+func newUnstructuredPodObj(ns, name, phase string, containerStatuses []interface{}) *unstructured.Unstructured {
+	obj := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": ns,
+		},
+		"spec": map[string]interface{}{
+			"nodeName": "node-1",
+		},
+		"status": map[string]interface{}{
+			"phase": phase,
+		},
+	}
+	if containerStatuses != nil {
+		obj["status"].(map[string]interface{})["containerStatuses"] = containerStatuses
+	}
+	return &unstructured.Unstructured{Object: obj}
+}

--- a/internal/tools/af_get_pods_test.go
+++ b/internal/tools/af_get_pods_test.go
@@ -166,7 +166,9 @@ func newUnstructuredPodObj(ns, name, phase string, containerStatuses []interface
 		},
 	}
 	if containerStatuses != nil {
-		obj["status"].(map[string]interface{})["containerStatuses"] = containerStatuses
+		if status, ok := obj["status"].(map[string]interface{}); ok {
+			status["containerStatuses"] = containerStatuses
+		}
 	}
 	return &unstructured.Unstructured{Object: obj}
 }

--- a/internal/tools/af_get_workloads.go
+++ b/internal/tools/af_get_workloads.go
@@ -1,0 +1,155 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+
+	"github.com/jordigilh/kubernaut-apifrontend/internal/auth"
+	"github.com/jordigilh/kubernaut-apifrontend/internal/validate"
+)
+
+// GetWorkloadsArgs defines the input for af_get_workloads.
+type GetWorkloadsArgs struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name,omitempty"`
+}
+
+// WorkloadReplicaStatus summarizes desired and observed replica counts.
+type WorkloadReplicaStatus struct {
+	Desired   int64 `json:"desired"`
+	Ready     int64 `json:"ready"`
+	Available int64 `json:"available"`
+}
+
+// WorkloadSummary is a compact view of a Deployment or StatefulSet.
+type WorkloadSummary struct {
+	Name       string                `json:"name"`
+	Kind       string                `json:"kind"`
+	Namespace  string                `json:"namespace"`
+	Replicas   WorkloadReplicaStatus `json:"replicas"`
+	Conditions []string              `json:"conditions,omitempty"`
+}
+
+// GetWorkloadsResult is the output of af_get_workloads.
+type GetWorkloadsResult struct {
+	Workloads []WorkloadSummary `json:"workloads"`
+	Count     int               `json:"count"`
+	Truncated bool              `json:"truncated,omitempty"`
+}
+
+var (
+	deploymentGVR  = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	statefulSetGVR = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}
+)
+
+// HandleGetWorkloads implements the af_get_workloads logic.
+func HandleGetWorkloads(ctx context.Context, client dynamic.Interface, args GetWorkloadsArgs) (GetWorkloadsResult, error) {
+	if client == nil {
+		return GetWorkloadsResult{}, ErrK8sUnavailable
+	}
+	if err := validate.Namespace(args.Namespace); err != nil {
+		return GetWorkloadsResult{}, fmt.Errorf("%w: %v", ErrInvalidInput, err)
+	}
+	if args.Name != "" {
+		if err := validate.ResourceName(args.Name); err != nil {
+			return GetWorkloadsResult{}, fmt.Errorf("%w: %v", ErrInvalidInput, err)
+		}
+	}
+
+	deployList, err := client.Resource(deploymentGVR).Namespace(args.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return GetWorkloadsResult{}, ToUserFriendlyError(err)
+	}
+	ssList, err := client.Resource(statefulSetGVR).Namespace(args.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return GetWorkloadsResult{}, ToUserFriendlyError(err)
+	}
+
+	result := make([]WorkloadSummary, 0, len(deployList.Items)+len(ssList.Items))
+	for i := range deployList.Items {
+		item := &deployList.Items[i]
+		if args.Name != "" && item.GetName() != args.Name {
+			continue
+		}
+		result = append(result, workloadSummaryFromUnstructured(item, "Deployment", args.Namespace))
+	}
+	for i := range ssList.Items {
+		item := &ssList.Items[i]
+		if args.Name != "" && item.GetName() != args.Name {
+			continue
+		}
+		result = append(result, workloadSummaryFromUnstructured(item, "StatefulSet", args.Namespace))
+	}
+
+	result, truncated := TrimSliceToFit(result)
+
+	return GetWorkloadsResult{
+		Workloads: result,
+		Count:     len(result),
+		Truncated: truncated,
+	}, nil
+}
+
+func workloadSummaryFromUnstructured(item *unstructured.Unstructured, kind, namespace string) WorkloadSummary {
+	desired, _, _ := unstructured.NestedInt64(item.Object, "spec", "replicas")
+	ready, _, _ := unstructured.NestedInt64(item.Object, "status", "readyReplicas")
+	available, _, _ := unstructured.NestedInt64(item.Object, "status", "availableReplicas")
+
+	return WorkloadSummary{
+		Name:      item.GetName(),
+		Kind:      kind,
+		Namespace: namespace,
+		Replicas: WorkloadReplicaStatus{
+			Desired:   desired,
+			Ready:     ready,
+			Available: available,
+		},
+		Conditions: extractWorkloadConditions(item.Object),
+	}
+}
+
+func extractWorkloadConditions(obj map[string]interface{}) []string {
+	conditions, found, _ := unstructured.NestedSlice(obj, "status", "conditions")
+	if !found {
+		return nil
+	}
+	var result []string
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		typ, _, _ := unstructured.NestedString(cond, "type")
+		status, _, _ := unstructured.NestedString(cond, "status")
+		reason, _, _ := unstructured.NestedString(cond, "reason")
+		line := typ + "=" + status
+		if reason != "" {
+			line += ": " + reason
+		}
+		result = append(result, line)
+	}
+	return result
+}
+
+// NewGetWorkloadsTool creates the af_get_workloads tool.
+// Uses DynamicClientFactory to obtain a per-request impersonated client (SEC-05).
+func NewGetWorkloadsTool(factory auth.DynamicClientFactory) (tool.Tool, error) {
+	return functiontool.New(functiontool.Config{
+		Name:        "af_get_workloads",
+		Description: "List Deployment and StatefulSet workloads in a namespace with replica status and conditions, optionally filtered by resource name",
+	}, func(ctx tool.Context, args GetWorkloadsArgs) (GetWorkloadsResult, error) {
+		client, err := factory(ctx)
+		if err != nil {
+			return GetWorkloadsResult{}, fmt.Errorf("%w", ErrK8sUnavailable)
+		}
+		return HandleGetWorkloads(ctx, client, args)
+	})
+}

--- a/internal/tools/af_get_workloads_test.go
+++ b/internal/tools/af_get_workloads_test.go
@@ -1,0 +1,169 @@
+package tools_test
+
+import (
+	"context"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/jordigilh/kubernaut-apifrontend/internal/tools"
+)
+
+func newUnstructuredDeployment(ns, name string, desired, ready, available int64) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": ns,
+			},
+			"spec": map[string]interface{}{
+				"replicas": desired,
+			},
+			"status": map[string]interface{}{
+				"readyReplicas":     ready,
+				"availableReplicas": available,
+			},
+		},
+	}
+}
+
+func newUnstructuredStatefulSet(ns, name string, desired, ready int64) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "StatefulSet",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": ns,
+			},
+			"spec": map[string]interface{}{
+				"replicas": desired,
+			},
+			"status": map[string]interface{}{
+				"readyReplicas": ready,
+			},
+		},
+	}
+}
+
+var _ = Describe("af_get_workloads", func() {
+	var (
+		deployGVR = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+		ssGVR     = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}
+	)
+
+	It("UT-AF-052-020: happy path returns Deployment and StatefulSet summaries", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{
+				deployGVR: "DeploymentList",
+				ssGVR:     "StatefulSetList",
+			},
+			newUnstructuredDeployment("prod", "web", 3, 3, 3),
+			newUnstructuredStatefulSet("prod", "db", 2, 2),
+		)
+
+		result, err := tools.HandleGetWorkloads(context.Background(), client, tools.GetWorkloadsArgs{Namespace: "prod"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Count).To(Equal(2))
+		Expect(result.Workloads[0].Kind).To(Equal("Deployment"))
+		Expect(result.Workloads[0].Name).To(Equal("web"))
+		Expect(result.Workloads[0].Replicas.Desired).To(Equal(int64(3)))
+		Expect(result.Workloads[1].Kind).To(Equal("StatefulSet"))
+	})
+
+	It("UT-AF-052-021: empty namespace rejected", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{deployGVR: "DeploymentList", ssGVR: "StatefulSetList"})
+		_, err := tools.HandleGetWorkloads(context.Background(), client, tools.GetWorkloadsArgs{Namespace: ""})
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ContainSubstring("invalid input")))
+	})
+
+	It("UT-AF-052-022: invalid namespace rejected", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{deployGVR: "DeploymentList", ssGVR: "StatefulSetList"})
+		_, err := tools.HandleGetWorkloads(context.Background(), client, tools.GetWorkloadsArgs{Namespace: "../etc"})
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ContainSubstring("invalid input")))
+	})
+
+	It("UT-AF-052-023: nil client returns ErrK8sUnavailable", func() {
+		_, err := tools.HandleGetWorkloads(context.Background(), nil, tools.GetWorkloadsArgs{Namespace: "default"})
+		Expect(err).To(MatchError(tools.ErrK8sUnavailable))
+	})
+
+	It("UT-AF-052-024: name filter returns only matching workload", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{
+				deployGVR: "DeploymentList",
+				ssGVR:     "StatefulSetList",
+			},
+			newUnstructuredDeployment("prod", "web", 3, 3, 3),
+			newUnstructuredDeployment("prod", "api", 2, 1, 1),
+		)
+
+		result, err := tools.HandleGetWorkloads(context.Background(), client, tools.GetWorkloadsArgs{Namespace: "prod", Name: "web"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Count).To(Equal(1))
+		Expect(result.Workloads[0].Name).To(Equal("web"))
+	})
+
+	It("UT-AF-052-025: invalid name rejected", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{deployGVR: "DeploymentList", ssGVR: "StatefulSetList"})
+		_, err := tools.HandleGetWorkloads(context.Background(), client, tools.GetWorkloadsArgs{
+			Namespace: "default",
+			Name:      "INVALID_NAME!!",
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ContainSubstring("invalid input")))
+	})
+
+	It("UT-AF-052-026: empty namespace returns empty list", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{
+				deployGVR: "DeploymentList",
+				ssGVR:     "StatefulSetList",
+			})
+
+		result, err := tools.HandleGetWorkloads(context.Background(), client, tools.GetWorkloadsArgs{Namespace: "empty-ns"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Count).To(Equal(0))
+	})
+
+	It("UT-AF-052-027: concurrent calls are safe", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{
+				deployGVR: "DeploymentList",
+				ssGVR:     "StatefulSetList",
+			},
+			newUnstructuredDeployment("test", "svc", 1, 1, 1),
+		)
+
+		var wg sync.WaitGroup
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, err := tools.HandleGetWorkloads(context.Background(), client, tools.GetWorkloadsArgs{Namespace: "test"})
+				Expect(err).NotTo(HaveOccurred())
+			}()
+		}
+		wg.Wait()
+	})
+})

--- a/internal/tools/af_list_events.go
+++ b/internal/tools/af_list_events.go
@@ -80,7 +80,7 @@ func HandleListEvents(ctx context.Context, client dynamic.Interface, args ListEv
 			InvolvedKind:  involvedKind,
 			InvolvedName:  involvedName,
 			Count:         count,
-			LastTimestamp:  lastTS,
+			LastTimestamp: lastTS,
 		})
 	}
 

--- a/internal/tools/af_list_events.go
+++ b/internal/tools/af_list_events.go
@@ -1,0 +1,109 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+
+	"github.com/jordigilh/kubernaut-apifrontend/internal/auth"
+	"github.com/jordigilh/kubernaut-apifrontend/internal/validate"
+)
+
+// ListEventsArgs defines the input for af_list_events.
+type ListEventsArgs struct {
+	Namespace string `json:"namespace"`
+	Reason    string `json:"reason,omitempty"`
+	Kind      string `json:"involved_kind,omitempty"`
+}
+
+// EventSummary is a compact view of a Kubernetes Event.
+type EventSummary struct {
+	Reason        string `json:"reason"`
+	Message       string `json:"message"`
+	InvolvedKind  string `json:"involved_kind"`
+	InvolvedName  string `json:"involved_name"`
+	Count         int64  `json:"count"`
+	LastTimestamp string `json:"last_timestamp,omitempty"`
+}
+
+// ListEventsResult is the output of af_list_events.
+type ListEventsResult struct {
+	Events    []EventSummary `json:"events"`
+	Count     int            `json:"count"`
+	Truncated bool           `json:"truncated,omitempty"`
+}
+
+var eventsGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "events"}
+
+// HandleListEvents implements the af_list_events logic.
+func HandleListEvents(ctx context.Context, client dynamic.Interface, args ListEventsArgs) (ListEventsResult, error) {
+	if client == nil {
+		return ListEventsResult{}, ErrK8sUnavailable
+	}
+	if err := validate.Namespace(args.Namespace); err != nil {
+		return ListEventsResult{}, fmt.Errorf("%w: %v", ErrInvalidInput, err)
+	}
+
+	list, err := client.Resource(eventsGVR).Namespace(args.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return ListEventsResult{}, ToUserFriendlyError(err)
+	}
+
+	result := make([]EventSummary, 0, len(list.Items))
+	for i := range list.Items {
+		item := &list.Items[i]
+		reason, _, _ := unstructured.NestedString(item.Object, "reason")
+		involvedKind, _, _ := unstructured.NestedString(item.Object, "involvedObject", "kind")
+
+		if args.Reason != "" && reason != args.Reason {
+			continue
+		}
+		if args.Kind != "" && involvedKind != args.Kind {
+			continue
+		}
+
+		message, _, _ := unstructured.NestedString(item.Object, "message")
+		involvedName, _, _ := unstructured.NestedString(item.Object, "involvedObject", "name")
+		count, _, _ := unstructured.NestedInt64(item.Object, "count")
+		lastTS, _, _ := unstructured.NestedString(item.Object, "lastTimestamp")
+
+		result = append(result, EventSummary{
+			Reason:        reason,
+			Message:       message,
+			InvolvedKind:  involvedKind,
+			InvolvedName:  involvedName,
+			Count:         count,
+			LastTimestamp:  lastTS,
+		})
+	}
+
+	result, truncated := TrimSliceToFit(result)
+
+	return ListEventsResult{
+		Events:    result,
+		Count:     len(result),
+		Truncated: truncated,
+	}, nil
+}
+
+// NewListEventsTool creates the af_list_events tool.
+// Uses DynamicClientFactory to obtain a per-request impersonated client (SEC-05).
+func NewListEventsTool(factory auth.DynamicClientFactory) (tool.Tool, error) {
+	return functiontool.New(functiontool.Config{
+		Name:        "af_list_events",
+		Description: "List Kubernetes Events in a namespace, optionally filtered by reason or involved resource kind",
+	}, func(ctx tool.Context, args ListEventsArgs) (ListEventsResult, error) {
+		client, err := factory(ctx)
+		if err != nil {
+			return ListEventsResult{}, fmt.Errorf("%w", ErrK8sUnavailable)
+		}
+		return HandleListEvents(ctx, client, args)
+	})
+}

--- a/internal/tools/af_list_events_test.go
+++ b/internal/tools/af_list_events_test.go
@@ -120,6 +120,41 @@ var _ = Describe("af_list_events", func() {
 		Expect(result.Count).To(Equal(1))
 		Expect(result.Events[0].Reason).To(Equal("BackOff"))
 	})
+
+	It("UT-AF-052-009: filters by involved_kind when provided", func() {
+		evPod := newUnstructuredEvent("prod", "ev-1", "BackOff", "container crash", "Pod", "web-abc")
+		evDeploy := newUnstructuredEvent("prod", "ev-2", "ScalingReplicaSet", "scaled up", "Deployment", "web")
+		evPod2 := newUnstructuredEvent("prod", "ev-3", "Pulled", "image pulled", "Pod", "web-def")
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{eventsGVRTest: "EventList"}, evPod, evDeploy, evPod2)
+
+		result, err := tools.HandleListEvents(ctx, client, tools.ListEventsArgs{
+			Namespace: "prod",
+			Kind:      "Pod",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Count).To(Equal(2))
+		for _, ev := range result.Events {
+			Expect(ev.InvolvedKind).To(Equal("Pod"))
+		}
+	})
+
+	It("UT-AF-052-010: filters by both reason and involved_kind", func() {
+		ev1 := newUnstructuredEvent("prod", "ev-1", "BackOff", "crash", "Pod", "pod1")
+		ev2 := newUnstructuredEvent("prod", "ev-2", "BackOff", "scale fail", "Deployment", "web")
+		ev3 := newUnstructuredEvent("prod", "ev-3", "Pulled", "ok", "Pod", "pod2")
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{eventsGVRTest: "EventList"}, ev1, ev2, ev3)
+
+		result, err := tools.HandleListEvents(ctx, client, tools.ListEventsArgs{
+			Namespace: "prod",
+			Reason:    "BackOff",
+			Kind:      "Pod",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Count).To(Equal(1))
+		Expect(result.Events[0].InvolvedName).To(Equal("pod1"))
+	})
 })
 
 func newUnstructuredEvent(ns, name, reason, message, involvedKind, involvedName string) *unstructured.Unstructured {

--- a/internal/tools/af_list_events_test.go
+++ b/internal/tools/af_list_events_test.go
@@ -1,0 +1,144 @@
+package tools_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/jordigilh/kubernaut-apifrontend/internal/tools"
+)
+
+var eventsGVRTest = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "events"}
+
+var _ = Describe("af_list_events", func() {
+	var (
+		ctx    context.Context
+		scheme *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+	})
+
+	It("UT-AF-052-001: returns events in namespace", func() {
+		ev := newUnstructuredEvent("prod", "pod-crash", "BackOff", "Back-off restarting failed container", "Pod", "my-pod")
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{eventsGVRTest: "EventList"}, ev)
+
+		result, err := tools.HandleListEvents(ctx, client, tools.ListEventsArgs{Namespace: "prod"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Count).To(Equal(1))
+		Expect(result.Events[0].Reason).To(Equal("BackOff"))
+		Expect(result.Events[0].InvolvedName).To(Equal("my-pod"))
+	})
+
+	It("UT-AF-052-002: empty namespace rejected", func() {
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{eventsGVRTest: "EventList"})
+		_, err := tools.HandleListEvents(ctx, client, tools.ListEventsArgs{Namespace: ""})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid input"))
+	})
+
+	It("UT-AF-052-003: path traversal namespace rejected", func() {
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{eventsGVRTest: "EventList"})
+		_, err := tools.HandleListEvents(ctx, client, tools.ListEventsArgs{Namespace: "../../etc/passwd"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid input"))
+	})
+
+	It("UT-AF-052-004: namespace with no events returns empty list", func() {
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{eventsGVRTest: "EventList"})
+		result, err := tools.HandleListEvents(ctx, client, tools.ListEventsArgs{Namespace: "empty-ns"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Count).To(Equal(0))
+		Expect(result.Events).To(BeEmpty())
+	})
+
+	It("UT-AF-052-005: large result is trimmed", func() {
+		var objs []runtime.Object
+		for i := range 200 {
+			objs = append(objs, newUnstructuredEvent("prod", fmt.Sprintf("ev-%d", i),
+				"Warning", strings.Repeat("long message content ", 20), "Pod", "pod-"+strings.Repeat("x", 50)))
+		}
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{
+				{Group: "", Version: "v1", Resource: "events"}: "EventList",
+			}, objs...)
+
+		result, err := tools.HandleListEvents(ctx, client, tools.ListEventsArgs{Namespace: "prod"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Truncated).To(BeTrue())
+		Expect(result.Count).To(BeNumerically("<", 200))
+	})
+
+	It("UT-AF-052-006: nil client returns ErrK8sUnavailable", func() {
+		_, err := tools.HandleListEvents(ctx, nil, tools.ListEventsArgs{Namespace: "prod"})
+		Expect(err).To(MatchError(tools.ErrK8sUnavailable))
+	})
+
+	It("UT-AF-052-007: concurrent calls are safe", func() {
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{eventsGVRTest: "EventList"})
+		var wg sync.WaitGroup
+		errs := make([]error, 10)
+		for i := range 10 {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				_, errs[idx] = tools.HandleListEvents(ctx, client, tools.ListEventsArgs{Namespace: "prod"})
+			}(i)
+		}
+		wg.Wait()
+		for _, e := range errs {
+			Expect(e).NotTo(HaveOccurred())
+		}
+	})
+
+	It("UT-AF-052-008: filters by reason when provided", func() {
+		ev1 := newUnstructuredEvent("prod", "ev-1", "BackOff", "msg1", "Pod", "pod1")
+		ev2 := newUnstructuredEvent("prod", "ev-2", "Scheduled", "msg2", "Pod", "pod2")
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{eventsGVRTest: "EventList"}, ev1, ev2)
+
+		result, err := tools.HandleListEvents(ctx, client, tools.ListEventsArgs{
+			Namespace: "prod",
+			Reason:    "BackOff",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Count).To(Equal(1))
+		Expect(result.Events[0].Reason).To(Equal("BackOff"))
+	})
+})
+
+func newUnstructuredEvent(ns, name, reason, message, involvedKind, involvedName string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Event",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": ns,
+			},
+			"reason":  reason,
+			"message": message,
+			"involvedObject": map[string]interface{}{
+				"kind": involvedKind,
+				"name": involvedName,
+			},
+			"count":         int64(1),
+			"lastTimestamp":  "2026-05-08T10:00:00Z",
+		},
+	}
+}

--- a/internal/tools/af_list_events_test.go
+++ b/internal/tools/af_list_events_test.go
@@ -138,7 +138,7 @@ func newUnstructuredEvent(ns, name, reason, message, involvedKind, involvedName 
 				"name": involvedName,
 			},
 			"count":         int64(1),
-			"lastTimestamp":  "2026-05-08T10:00:00Z",
+			"lastTimestamp": "2026-05-08T10:00:00Z",
 		},
 	}
 }

--- a/internal/tools/af_resolve_owner.go
+++ b/internal/tools/af_resolve_owner.go
@@ -1,0 +1,176 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+
+	"github.com/jordigilh/kubernaut-apifrontend/internal/auth"
+	"github.com/jordigilh/kubernaut-apifrontend/internal/validate"
+)
+
+const maxOwnerDepth = 10
+
+// ResolveOwnerArgs defines the input for af_resolve_owner.
+type ResolveOwnerArgs struct {
+	Namespace string `json:"namespace"`
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+}
+
+// OwnerChainEntry is one resource in an ownership chain.
+type OwnerChainEntry struct {
+	Kind       string `json:"kind"`
+	Name       string `json:"name"`
+	APIVersion string `json:"apiVersion"`
+}
+
+// ResolveOwnerResult is the output of af_resolve_owner.
+type ResolveOwnerResult struct {
+	Chain    []OwnerChainEntry `json:"chain"`
+	RootKind string            `json:"root_kind"`
+	RootName string            `json:"root_name"`
+}
+
+func kindToGVR(kind string) (schema.GroupVersionResource, bool) {
+	switch kind {
+	case "Pod":
+		return schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, true
+	case "ReplicationController":
+		return schema.GroupVersionResource{Group: "", Version: "v1", Resource: "replicationcontrollers"}, true
+	case "ReplicaSet":
+		return schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}, true
+	case "Deployment":
+		return schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}, true
+	case "StatefulSet":
+		return schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}, true
+	case "DaemonSet":
+		return schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "daemonsets"}, true
+	case "Job":
+		return schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "jobs"}, true
+	case "CronJob":
+		return schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "cronjobs"}, true
+	default:
+		return schema.GroupVersionResource{}, false
+	}
+}
+
+func pickOwnerRef(obj map[string]interface{}) (kind, name string, ok bool) {
+	refs, found, _ := unstructured.NestedSlice(obj, "metadata", "ownerReferences")
+	if !found || len(refs) == 0 {
+		return "", "", false
+	}
+	var chosen map[string]interface{}
+	var first map[string]interface{}
+	for _, r := range refs {
+		ref, isMap := r.(map[string]interface{})
+		if !isMap {
+			continue
+		}
+		if first == nil {
+			first = ref
+		}
+		if ctrl, has, _ := unstructured.NestedBool(ref, "controller"); has && ctrl {
+			chosen = ref
+			break
+		}
+	}
+	if chosen == nil {
+		chosen = first
+	}
+	if chosen == nil {
+		return "", "", false
+	}
+	kind, _, _ = unstructured.NestedString(chosen, "kind")
+	name, _, _ = unstructured.NestedString(chosen, "name")
+	if kind == "" || name == "" {
+		return "", "", false
+	}
+	return kind, name, true
+}
+
+// HandleResolveOwner implements the af_resolve_owner logic.
+func HandleResolveOwner(ctx context.Context, client dynamic.Interface, args ResolveOwnerArgs) (ResolveOwnerResult, error) {
+	var empty ResolveOwnerResult
+	if client == nil {
+		return empty, ErrK8sUnavailable
+	}
+	if err := validate.Namespace(args.Namespace); err != nil {
+		return empty, fmt.Errorf("%w: %v", ErrInvalidInput, err)
+	}
+	if err := validate.ResourceName(args.Name); err != nil {
+		return empty, fmt.Errorf("%w: %v", ErrInvalidInput, err)
+	}
+	if args.Kind == "" {
+		return empty, fmt.Errorf("%w: kind must not be empty", ErrInvalidInput)
+	}
+
+	currentKind, currentName := args.Kind, args.Name
+	visited := make(map[string]struct{})
+	chain := make([]OwnerChainEntry, 0, maxOwnerDepth)
+
+	for len(chain) < maxOwnerDepth {
+		key := currentKind + "/" + currentName
+		if _, seen := visited[key]; seen {
+			break
+		}
+
+		gvr, known := kindToGVR(currentKind)
+		if !known {
+			if len(chain) == 0 {
+				return empty, fmt.Errorf("%w: unsupported kind %q", ErrInvalidInput, currentKind)
+			}
+			break
+		}
+		visited[key] = struct{}{}
+
+		obj, err := client.Resource(gvr).Namespace(args.Namespace).Get(ctx, currentName, metav1.GetOptions{})
+		if err != nil {
+			if len(chain) > 0 {
+				break
+			}
+			return empty, ToUserFriendlyError(err)
+		}
+
+		chain = append(chain, OwnerChainEntry{
+			Kind:       obj.GetKind(),
+			Name:       obj.GetName(),
+			APIVersion: obj.GetAPIVersion(),
+		})
+
+		nextKind, nextName, hasOwner := pickOwnerRef(obj.Object)
+		if !hasOwner {
+			break
+		}
+		currentKind, currentName = nextKind, nextName
+	}
+
+	result := ResolveOwnerResult{Chain: chain}
+	if n := len(chain); n > 0 {
+		result.RootKind = chain[n-1].Kind
+		result.RootName = chain[n-1].Name
+	}
+	return result, nil
+}
+
+// NewResolveOwnerTool creates the af_resolve_owner tool.
+// Uses DynamicClientFactory to obtain a per-request impersonated client (SEC-05).
+func NewResolveOwnerTool(factory auth.DynamicClientFactory) (tool.Tool, error) {
+	return functiontool.New(functiontool.Config{
+		Name:        "af_resolve_owner",
+		Description: "Resolve the ownership chain of a Kubernetes resource up to the root workload (max 10 hops)",
+	}, func(ctx tool.Context, args ResolveOwnerArgs) (ResolveOwnerResult, error) {
+		client, err := factory(ctx)
+		if err != nil {
+			return ResolveOwnerResult{}, fmt.Errorf("%w", ErrK8sUnavailable)
+		}
+		return HandleResolveOwner(ctx, client, args)
+	})
+}

--- a/internal/tools/af_resolve_owner_test.go
+++ b/internal/tools/af_resolve_owner_test.go
@@ -27,12 +27,14 @@ func newUnstructuredWithOwner(apiVersion, kind, ns, name, ownerKind, ownerName s
 		},
 	}
 	if ownerKind != "" {
-		obj.Object["metadata"].(map[string]interface{})["ownerReferences"] = []interface{}{
-			map[string]interface{}{
-				"kind":       ownerKind,
-				"name":       ownerName,
-				"controller": controller,
-			},
+		if meta, ok := obj.Object["metadata"].(map[string]interface{}); ok {
+			meta["ownerReferences"] = []interface{}{
+				map[string]interface{}{
+					"kind":       ownerKind,
+					"name":       ownerName,
+					"controller": controller,
+				},
+			}
 		}
 	}
 	return obj

--- a/internal/tools/af_resolve_owner_test.go
+++ b/internal/tools/af_resolve_owner_test.go
@@ -1,0 +1,169 @@
+package tools_test
+
+import (
+	"context"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/jordigilh/kubernaut-apifrontend/internal/tools"
+)
+
+func newUnstructuredWithOwner(apiVersion, kind, ns, name, ownerKind, ownerName string, controller bool) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": apiVersion,
+			"kind":       kind,
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": ns,
+			},
+		},
+	}
+	if ownerKind != "" {
+		obj.Object["metadata"].(map[string]interface{})["ownerReferences"] = []interface{}{
+			map[string]interface{}{
+				"kind":       ownerKind,
+				"name":       ownerName,
+				"controller": controller,
+			},
+		}
+	}
+	return obj
+}
+
+var _ = Describe("af_resolve_owner", func() {
+	var (
+		podGVR    = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+		rsGVR     = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}
+		deployGVR = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	)
+
+	It("UT-AF-052-030: resolves Pod -> ReplicaSet -> Deployment chain", func() {
+		pod := newUnstructuredWithOwner("v1", "Pod", "ns", "web-abc-123", "ReplicaSet", "web-abc", true)
+		rs := newUnstructuredWithOwner("apps/v1", "ReplicaSet", "ns", "web-abc", "Deployment", "web", true)
+		deploy := newUnstructuredWithOwner("apps/v1", "Deployment", "ns", "web", "", "", false)
+
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{
+				podGVR:    "PodList",
+				rsGVR:     "ReplicaSetList",
+				deployGVR: "DeploymentList",
+			},
+			pod, rs, deploy,
+		)
+
+		result, err := tools.HandleResolveOwner(context.Background(), client, tools.ResolveOwnerArgs{
+			Namespace: "ns", Kind: "Pod", Name: "web-abc-123",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Chain).To(HaveLen(3))
+		Expect(result.RootKind).To(Equal("Deployment"))
+		Expect(result.RootName).To(Equal("web"))
+	})
+
+	It("UT-AF-052-031: single resource with no owner returns chain of 1", func() {
+		deploy := newUnstructuredWithOwner("apps/v1", "Deployment", "ns", "standalone", "", "", false)
+
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{deployGVR: "DeploymentList"},
+			deploy,
+		)
+
+		result, err := tools.HandleResolveOwner(context.Background(), client, tools.ResolveOwnerArgs{
+			Namespace: "ns", Kind: "Deployment", Name: "standalone",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Chain).To(HaveLen(1))
+		Expect(result.RootKind).To(Equal("Deployment"))
+	})
+
+	It("UT-AF-052-032: unsupported kind as starting point returns error", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, nil)
+
+		_, err := tools.HandleResolveOwner(context.Background(), client, tools.ResolveOwnerArgs{
+			Namespace: "ns", Kind: "CustomThing", Name: "my-custom",
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ContainSubstring("unsupported kind")))
+	})
+
+	It("UT-AF-052-033: empty namespace rejected", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, nil)
+
+		_, err := tools.HandleResolveOwner(context.Background(), client, tools.ResolveOwnerArgs{
+			Namespace: "", Kind: "Pod", Name: "foo",
+		})
+		Expect(err).To(MatchError(ContainSubstring("invalid input")))
+	})
+
+	It("UT-AF-052-034: empty name rejected", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, nil)
+
+		_, err := tools.HandleResolveOwner(context.Background(), client, tools.ResolveOwnerArgs{
+			Namespace: "ns", Kind: "Pod", Name: "",
+		})
+		Expect(err).To(MatchError(ContainSubstring("invalid input")))
+	})
+
+	It("UT-AF-052-035: empty kind rejected", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, nil)
+
+		_, err := tools.HandleResolveOwner(context.Background(), client, tools.ResolveOwnerArgs{
+			Namespace: "ns", Kind: "", Name: "foo",
+		})
+		Expect(err).To(MatchError(ContainSubstring("invalid input")))
+	})
+
+	It("UT-AF-052-036: nil client returns ErrK8sUnavailable", func() {
+		_, err := tools.HandleResolveOwner(context.Background(), nil, tools.ResolveOwnerArgs{
+			Namespace: "ns", Kind: "Pod", Name: "foo",
+		})
+		Expect(err).To(MatchError(tools.ErrK8sUnavailable))
+	})
+
+	It("UT-AF-052-037: resource not found at start returns error", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{podGVR: "PodList"})
+
+		_, err := tools.HandleResolveOwner(context.Background(), client, tools.ResolveOwnerArgs{
+			Namespace: "ns", Kind: "Pod", Name: "nonexistent",
+		})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("UT-AF-052-038: concurrent calls are safe", func() {
+		deploy := newUnstructuredWithOwner("apps/v1", "Deployment", "ns", "web", "", "", false)
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{deployGVR: "DeploymentList"},
+			deploy,
+		)
+
+		var wg sync.WaitGroup
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, err := tools.HandleResolveOwner(context.Background(), client, tools.ResolveOwnerArgs{
+					Namespace: "ns", Kind: "Deployment", Name: "web",
+				})
+				Expect(err).NotTo(HaveOccurred())
+			}()
+		}
+		wg.Wait()
+	})
+})

--- a/internal/tools/af_resolve_owner_test.go
+++ b/internal/tools/af_resolve_owner_test.go
@@ -2,6 +2,7 @@ package tools_test
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -167,5 +168,112 @@ var _ = Describe("af_resolve_owner", func() {
 			}()
 		}
 		wg.Wait()
+	})
+
+	It("UT-AF-052-039: cycle detection stops traversal (A->B->A)", func() {
+		rsA := newUnstructuredWithOwner("apps/v1", "ReplicaSet", "ns", "rs-a", "ReplicaSet", "rs-b", true)
+		rsB := newUnstructuredWithOwner("apps/v1", "ReplicaSet", "ns", "rs-b", "ReplicaSet", "rs-a", true)
+
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rsGVR: "ReplicaSetList"},
+			rsA, rsB,
+		)
+
+		result, err := tools.HandleResolveOwner(context.Background(), client, tools.ResolveOwnerArgs{
+			Namespace: "ns", Kind: "ReplicaSet", Name: "rs-a",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Chain).To(HaveLen(2))
+		Expect(result.RootKind).To(Equal("ReplicaSet"))
+	})
+
+	It("UT-AF-052-040: unsupported kind mid-chain returns partial result", func() {
+		pod := newUnstructuredWithOwner("v1", "Pod", "ns", "job-pod", "Job", "my-job", true)
+		job := newUnstructuredWithOwner("batch/v1", "Job", "ns", "my-job", "CustomKind", "owner", true)
+
+		scheme := runtime.NewScheme()
+		jobGVR := schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "jobs"}
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{
+				podGVR: "PodList",
+				jobGVR: "JobList",
+			},
+			pod, job,
+		)
+
+		result, err := tools.HandleResolveOwner(context.Background(), client, tools.ResolveOwnerArgs{
+			Namespace: "ns", Kind: "Pod", Name: "job-pod",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Chain).To(HaveLen(2))
+		Expect(result.RootKind).To(Equal("Job"))
+		Expect(result.RootName).To(Equal("my-job"))
+	})
+
+	It("UT-AF-052-041: max depth (10) stops traversal with partial chain", func() {
+		scheme := runtime.NewScheme()
+		objs := make([]runtime.Object, 12)
+		for i := 0; i < 12; i++ {
+			name := fmt.Sprintf("rs-%d", i)
+			ownerName := ""
+			if i < 11 {
+				ownerName = fmt.Sprintf("rs-%d", i+1)
+			}
+			objs[i] = newUnstructuredWithOwner("apps/v1", "ReplicaSet", "ns", name, "ReplicaSet", ownerName, true)
+		}
+
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{rsGVR: "ReplicaSetList"},
+			objs...,
+		)
+
+		result, err := tools.HandleResolveOwner(context.Background(), client, tools.ResolveOwnerArgs{
+			Namespace: "ns", Kind: "ReplicaSet", Name: "rs-0",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(result.Chain)).To(BeNumerically("<=", 10))
+	})
+
+	It("UT-AF-052-042: prefers controller owner over non-controller", func() {
+		pod := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"name":      "multi-owner",
+					"namespace": "ns",
+					"ownerReferences": []interface{}{
+						map[string]interface{}{
+							"kind":       "ReplicaSet",
+							"name":       "non-controller-rs",
+							"controller": false,
+						},
+						map[string]interface{}{
+							"kind":       "ReplicaSet",
+							"name":       "controller-rs",
+							"controller": true,
+						},
+					},
+				},
+			},
+		}
+		controllerRS := newUnstructuredWithOwner("apps/v1", "ReplicaSet", "ns", "controller-rs", "", "", false)
+
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{
+				podGVR: "PodList",
+				rsGVR:  "ReplicaSetList",
+			},
+			pod, controllerRS,
+		)
+
+		result, err := tools.HandleResolveOwner(context.Background(), client, tools.ResolveOwnerArgs{
+			Namespace: "ns", Kind: "Pod", Name: "multi-owner",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Chain).To(HaveLen(2))
+		Expect(result.Chain[1].Name).To(Equal("controller-rs"))
 	})
 })

--- a/internal/tools/crd_tools.go
+++ b/internal/tools/crd_tools.go
@@ -15,6 +15,8 @@ import (
 
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
+
+	"github.com/jordigilh/kubernaut-apifrontend/internal/auth"
 )
 
 var rrGVR = schema.GroupVersionResource{Group: "kubernaut.ai", Version: "v1alpha1", Resource: "remediationrequests"}
@@ -225,7 +227,7 @@ func NewSubmitSignalTool(client dynamic.Interface) (tool.Tool, error) {
 		Name:        "kubernaut_submit_signal",
 		Description: "Submit a new incident signal for triage and potential remediation",
 	}, func(ctx tool.Context, args SubmitSignalArgs) (SubmitSignalResult, error) {
-		return HandleSubmitSignal(ctx, client, args, "system")
+		return HandleSubmitSignal(ctx, client, args, usernameFromContext(ctx))
 	})
 }
 
@@ -293,8 +295,17 @@ func NewApproveTool(client dynamic.Interface) (tool.Tool, error) {
 		Name:        "kubernaut_approve",
 		Description: "Approve or reject a pending remediation approval request",
 	}, func(ctx tool.Context, args ApproveArgs) (ApproveResult, error) {
-		return HandleApprove(ctx, client, args, "system")
+		return HandleApprove(ctx, client, args, usernameFromContext(ctx))
 	})
+}
+
+// usernameFromContext extracts the authenticated username from tool context.
+// Falls back to "system" when no identity is present (e.g. in tests).
+func usernameFromContext(ctx context.Context) string {
+	if identity := auth.UserIdentityFromContext(ctx); identity != nil && identity.Username != "" {
+		return identity.Username
+	}
+	return "system"
 }
 
 // CancelRemediationArgs defines the input for kubernaut_cancel_remediation.

--- a/internal/tools/helpers.go
+++ b/internal/tools/helpers.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -20,6 +21,13 @@ var ErrAlreadyTerminal = errors.New("already in terminal state")
 
 // ErrK8sUnavailable indicates the K8s cluster is not reachable.
 var ErrK8sUnavailable = errors.New("kubernetes cluster is not available — contact your administrator")
+
+// ErrInvalidInput indicates input validation failed (RFC 1123, empty fields, etc.).
+var ErrInvalidInput = errors.New("invalid input")
+
+// maxToolOutputBytes is the maximum serialized output size for tool results.
+// Matches the 4KB threshold used by session.TrimToolResult for etcd safety.
+const maxToolOutputBytes = 4096
 
 // ParseRRID parses an rr_id shorthand (namespace/name) into its components.
 // If rr_id is empty, namespace and name are returned as-is.
@@ -79,4 +87,23 @@ func IsTerminalPhase(phase string) bool {
 		return true
 	}
 	return false
+}
+
+// TrimSliceToFit removes trailing elements from a slice until its JSON
+// serialization fits within maxToolOutputBytes, returning the trimmed slice
+// and whether any trimming occurred. The marshal function should serialize
+// the slice to JSON bytes.
+func TrimSliceToFit[T any](items []T) ([]T, bool) {
+	output, _ := json.Marshal(items)
+	if len(output) <= maxToolOutputBytes {
+		return items, false
+	}
+	for len(items) > 1 {
+		items = items[:len(items)-1]
+		output, _ = json.Marshal(items)
+		if len(output) <= maxToolOutputBytes {
+			break
+		}
+	}
+	return items, true
 }

--- a/internal/validate/k8s.go
+++ b/internal/validate/k8s.go
@@ -1,0 +1,41 @@
+// Package validate provides reusable input validation helpers for Kubernetes
+// resource names and namespaces, wrapping k8s.io/apimachinery/pkg/util/validation
+// to present user-friendly error messages.
+package validate
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// Namespace validates that ns is a valid Kubernetes namespace (RFC 1123 DNS label).
+func Namespace(ns string) error {
+	if ns == "" {
+		return fmt.Errorf("namespace must not be empty")
+	}
+	if errs := validation.IsDNS1123Label(ns); len(errs) > 0 {
+		return fmt.Errorf("invalid namespace %q: %s", ns, strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// ResourceName validates that name is a valid Kubernetes resource name (RFC 1123 DNS subdomain).
+func ResourceName(name string) error {
+	if name == "" {
+		return fmt.Errorf("resource name must not be empty")
+	}
+	if errs := validation.IsDNS1123Subdomain(name); len(errs) > 0 {
+		return fmt.Errorf("invalid resource name %q: %s", name, strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// LabelValue validates that v is a valid Kubernetes label value.
+func LabelValue(v string) error {
+	if errs := validation.IsValidLabelValue(v); len(errs) > 0 {
+		return fmt.Errorf("invalid label value %q: %s", v, strings.Join(errs, "; "))
+	}
+	return nil
+}

--- a/internal/validate/k8s_test.go
+++ b/internal/validate/k8s_test.go
@@ -1,0 +1,103 @@
+package validate_test
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut-apifrontend/internal/validate"
+)
+
+func TestValidateSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Validate Suite")
+}
+
+var _ = Describe("Namespace", func() {
+	DescribeTable("valid namespaces",
+		func(ns string) {
+			Expect(validate.Namespace(ns)).To(Succeed())
+		},
+		Entry("simple", "default"),
+		Entry("with hyphens", "kube-system"),
+		Entry("with numbers", "ns-123"),
+		Entry("single char", "a"),
+		Entry("max length (63 chars)", strings.Repeat("a", 63)),
+	)
+
+	DescribeTable("invalid namespaces",
+		func(ns string, substr string) {
+			err := validate.Namespace(ns)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(substr))
+		},
+		Entry("empty", "", "must not be empty"),
+		Entry("too long (64 chars)", strings.Repeat("a", 64), "invalid namespace"),
+		Entry("uppercase", "MyNamespace", "invalid namespace"),
+		Entry("leading hyphen", "-invalid", "invalid namespace"),
+		Entry("trailing hyphen", "invalid-", "invalid namespace"),
+		Entry("dot", "my.namespace", "invalid namespace"),
+		Entry("slash", "../../etc", "invalid namespace"),
+		Entry("underscore", "my_namespace", "invalid namespace"),
+		Entry("space", "my namespace", "invalid namespace"),
+		Entry("unicode", "名前空間", "invalid namespace"),
+	)
+})
+
+var _ = Describe("ResourceName", func() {
+	DescribeTable("valid resource names",
+		func(name string) {
+			Expect(validate.ResourceName(name)).To(Succeed())
+		},
+		Entry("simple", "my-pod"),
+		Entry("with dots", "my.pod.v1"),
+		Entry("with hyphens and numbers", "pod-123-abc"),
+		Entry("max length (253 chars)", strings.Repeat("a", 253)),
+	)
+
+	DescribeTable("invalid resource names",
+		func(name string, substr string) {
+			err := validate.ResourceName(name)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(substr))
+		},
+		Entry("empty", "", "must not be empty"),
+		Entry("too long (254 chars)", strings.Repeat("a", 254), "invalid resource name"),
+		Entry("uppercase", "MyPod", "invalid resource name"),
+		Entry("leading hyphen", "-pod", "invalid resource name"),
+		Entry("trailing hyphen", "pod-", "invalid resource name"),
+		Entry("slash", "ns/pod", "invalid resource name"),
+		Entry("space", "my pod", "invalid resource name"),
+	)
+})
+
+var _ = Describe("LabelValue", func() {
+	DescribeTable("valid label values",
+		func(v string) {
+			Expect(validate.LabelValue(v)).To(Succeed())
+		},
+		Entry("empty (optional labels)", ""),
+		Entry("simple", "Deployment"),
+		Entry("with hyphens", "my-value"),
+		Entry("with dots", "v1.2.3"),
+		Entry("with underscores", "my_value"),
+		Entry("max length (63 chars)", strings.Repeat("a", 63)),
+		Entry("alphanumeric start/end", "a123b"),
+	)
+
+	DescribeTable("invalid label values",
+		func(v string, substr string) {
+			err := validate.LabelValue(v)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(substr))
+		},
+		Entry("too long (64 chars)", strings.Repeat("a", 64), "invalid label value"),
+		Entry("leading hyphen", "-value", "invalid label value"),
+		Entry("trailing hyphen", "value-", "invalid label value"),
+		Entry("slash", "ns/name", "invalid label value"),
+		Entry("space", "my value", "invalid label value"),
+		Entry("unicode", "日本語", "invalid label value"),
+	)
+})


### PR DESCRIPTION
## Summary

- **NL Signal Intake (#52):** 6 new triage tools (`af_list_events`, `af_get_pods`, `af_get_workloads`, `af_resolve_owner`, `af_check_existing_rr`, `af_create_rr`) with per-request user impersonation for read-only K8s queries and singleflight deduplication for RR creation
- **Session Production Wiring (#56):** `SessionServiceDecorator` enriches sessions with authenticated user identity; `DynamicClientFactory` pattern for impersonated Kubernetes clients
- **Security Hardening (SEC-05, FED-04):** User impersonation enforces least-privilege on triage tools; structured `tool.invoked` audit events emitted for every tool execution (NIST AU-12)
- **FedRAMP Documentation:** 5 substantive security/architecture documents mapping directly to implemented code — Authentication & RBAC, Service Boundary, Security Testing Pipeline, Audit Event Catalog, and Tool Execution Model

## Changes

### Commit 1: Core Feature (`feat(tools)`)
- 6 new tool implementations in `internal/tools/af_*.go`
- `internal/validate/` package for RFC 1123 input validation
- `internal/auth/dynamic_impersonation.go` — `DynamicClientFactory` for per-request impersonation
- `internal/session/decorator.go` — `SessionServiceDecorator` for session enrichment
- Updated `internal/agent/root.go` with RBAC guard, metrics, and audit callbacks
- Extended `rbac_roles.yaml` with new tool grants across 3 roles
- Updated ClusterRole with read permissions for core K8s resources

### Commit 2: Tests (`test`)
- 7 new test files for all `af_*` tools + session decorator
- Updated 5 existing test files for new tool count (14→20) and prefix acceptance

### Commit 3: Test Plans (`docs(test)`)
- IEEE 829 test plans for #52 and #56

### Commit 4: Security Documentation (`docs(security)`)
- `docs/security/AUDIT_EVENT_CATALOG.md` — All event types mapped to NIST controls
- `docs/security/AUTHENTICATION_AND_RBAC.md` — Auth flow, RBAC matrix, impersonation model
- `docs/security/SERVICE_BOUNDARY.md` — Trust boundary, ingress/egress, rate limiting
- `docs/security/SECURITY_TESTING.md` — Testing pyramid, CI gates, vulnerability scanning
- `docs/design/TOOL_EXECUTION_MODEL.md` — Callback chain, client resolution, output safety

## Test plan

- [ ] `make test-unit` passes with race detector (all 77 test files)
- [ ] `make lint` passes
- [ ] `make validate-maturity-ci` passes
- [ ] New tools registered in MCP registry and agent card
- [ ] RBAC role counts match expected values (sre:20, ai-orchestrator:16, observability:8)
- [ ] Impersonation factory creates user-scoped clients (verified in `af_*_test.go`)

Closes #52, closes #56

Made with [Cursor](https://cursor.com)