### PR TITLE
docs: severity triage design document, ADR-021, and documentation readiness audit fixes (#92)

### DIFF
--- a/docs/adr/ADR-021-severity-triage.md
+++ b/docs/adr/ADR-021-severity-triage.md
@@ -1,0 +1,62 @@
+# ADR-021: Severity Triage Pipeline Design
+
+**Status:** Accepted
+**Date:** 2026-05-10
+**Context:** Issue #92 — Three-Tier Severity Triage for Manual Signals
+
+---
+
+## Context
+
+When a manual signal arrives without a user-supplied severity (via `af_create_rr` or `kubernaut_submit_signal`), the API Frontend must determine severity before creating the RemediationRequest CRD. The kubernaut pipeline requires severity for classification, prioritization, and routing.
+
+The key design tension is between:
+- **Availability** — always producing a severity (even a guess) so the pipeline can proceed
+- **Correctness** — never producing an unjustified severity that could misroute remediations
+
+## Decision
+
+### 1. LLM is mandatory — panic on nil
+
+`NewTriager` panics if the `LLMTriager` dependency is nil. The pipeline requires an LLM fallback as the last resort to guarantee a justified result. This follows the same startup fail-fast pattern as `RegisterTools` panicking on nil `RBACRoles`.
+
+**Rationale:** A triage pipeline without LLM can only derive severity from Prometheus. If Prometheus is unreachable (network, downtime, misconfiguration), every triage call would fail. Making LLM optional would require a hardcoded default, which violates the correctness constraint.
+
+### 2. No silent defaults — Tier 3 errors propagate
+
+If the LLM call fails at Tier 3 (the last resort), the error is propagated to the caller. The pipeline never returns a hardcoded "medium" or any other default severity.
+
+**Rationale:** A silent default masks pipeline failures. An SRE cannot distinguish "triage determined medium" from "triage failed and we guessed medium." Every severity value must be traceable to a source (firing alert, pending rule, rule evaluation, or LLM classification).
+
+### 3. PromQL expressions are server-controlled only
+
+All PromQL expressions used in Tier 2 instant queries originate from Prometheus `/api/v1/rules` responses. User input is never interpolated into query strings.
+
+**Rationale:** Prevents PromQL injection. The `ExtractLabelMatchers` function reads ASTs — it does not construct queries from user data.
+
+### 4. Lazy cache eviction (no background goroutines)
+
+The rules cache uses TTL-based lazy eviction checked on `Get()`. There is no background refresh goroutine.
+
+**Rationale:** Avoids goroutine lifecycle complexity (`#62: Starting goroutine without knowing when to stop` from 100 Go Mistakes). A 30-second TTL with lazy check is sufficient — the cache is only read during triage calls.
+
+## Consequences
+
+- The AF binary **cannot start** without a configured LLM provider (intentional fail-fast)
+- Triage failures surface as errors to the tool caller, which must handle them (e.g., retry, surface to user)
+- Prometheus downtime degrades triage to LLM-only (Tier 3) but does not cause failure
+- LLM downtime causes triage failure — this is the intended behavior, not a deficiency
+
+## Alternatives Considered
+
+| Alternative | Rejected Because |
+|-------------|-----------------|
+| Default to "medium" when LLM is nil or fails | Masks failures; produces unjustified severity; SRE cannot distinguish default from derived |
+| Make LLM optional, fall back to "unknown" | The `unknown` severity is not in the canonical set and causes downstream misrouting |
+| Filter `tools/list` by RBAC instead of runtime enforcement | RBAC state can change between listing and calling; runtime enforcement is more accurate (see ADR-020) |
+| Background cache refresh goroutine | Adds goroutine lifecycle complexity with minimal benefit over lazy TTL |
+
+---
+
+*Design document: `docs/design/SEVERITY_TRIAGE.md`*
+*Test plan: `docs/tests/92/test_plan.md`*

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,6 +35,8 @@ Each ADR follows the standard structure:
 | [ADR-017](ADR-017-crd-pii-classification.md) | CRD PII data classification and retention policy | Accepted | 2026-05-06 |
 | [ADR-018](ADR-018-impersonation-risk-acceptance.md) | Impersonation risk acceptance and boundary enforcement | Accepted | 2026-05-07 |
 | [ADR-019](ADR-019-audit-buffer-volatility.md) | Audit buffer volatility and overflow handling | Accepted | 2026-05-08 |
+| [ADR-020](ADR-020-mcp-bridge-rbac-runtime.md) | MCP bridge RBAC: runtime enforcement only | Accepted | 2026-05-09 |
+| [ADR-021](ADR-021-severity-triage.md) | Severity triage: mandatory LLM, no silent defaults | Accepted | 2026-05-10 |
 
 ## Adding New ADRs
 

--- a/docs/design/ARCHITECTURE.md
+++ b/docs/design/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # kubernaut-apifrontend Architecture Design Document
 
-**Version:** 1.0
+**Version:** 1.1
 **Status:** Accepted
-**Last Updated:** 2026-05-03
+**Last Updated:** 2026-05-10
 
 ---
 
@@ -110,56 +110,102 @@ kubernaut-apifrontend/
 │   └── apifrontend/
 │       └── main.go                # Entry point, wires all components
 ├── internal/
-│   ├── handler/
-│   │   ├── a2a.go                 # A2A JSON-RPC request handler
-│   │   ├── mcp.go                 # MCP Streamable HTTP handler
-│   │   ├── agentcard.go           # /.well-known/agent-card.json
-│   │   └── health.go              # /healthz, /readyz
+│   ├── agent/
+│   │   ├── root.go                # ADK agent config, tool registration, callbacks
+│   │   ├── config.go              # Agent creation config
+│   │   ├── deps.go                # Dependency injection container
+│   │   └── prompt.go              # System prompt construction
+│   ├── audit/
+│   │   ├── audit.go               # Audit event types and Emitter interface
+│   │   └── buffered.go            # BufferedEmitter with overflow protection
 │   ├── auth/
 │   │   ├── jwt.go                 # Multi-issuer JWT validation (KEP-3331)
+│   │   ├── middleware.go          # Auth middleware chain
 │   │   ├── impersonation.go       # K8s impersonation header injection
-│   │   └── middleware.go          # Auth middleware chain
-│   ├── llm/
-│   │   ├── client.go              # LLM provider abstraction
-│   │   ├── orchestrator.go        # Triage orchestration (system prompt + tools)
-│   │   └── prompt.go              # System prompt construction
+│   │   ├── dynamic_impersonation.go # Per-request DynamicClientFactory
+│   │   ├── tokenreview.go         # K8s TokenReview validation
+│   │   ├── jwks_cache.go          # JWKS response caching
+│   │   ├── jwt_delegation.go      # JWT forwarding to downstream services
+│   │   ├── config.go              # Auth configuration
+│   │   ├── context.go             # UserIdentity context helpers
+│   │   └── types.go               # Auth type definitions
+│   ├── config/
+│   │   ├── config.go              # YAML config parsing and validation
+│   │   └── hotreload.go           # Configuration hot-reload
+│   ├── controller/
+│   │   └── ttl.go                 # InvestigationSession TTL controller
+│   ├── ds/
+│   │   ├── client.go              # DataStorage REST client
+│   │   └── ogen_client.go         # Generated ogen client wrapper
+│   ├── handler/
+│   │   ├── router.go              # HTTP route registration
+│   │   ├── mcp.go                 # MCP Streamable HTTP handler
+│   │   ├── mcp_bridge.go          # MCP tool bridge (RBAC, dispatch, metrics)
+│   │   ├── mcptools.go            # MCP tool registry (20 tools)
+│   │   ├── agentcard.go           # /.well-known/agent-card.json
+│   │   ├── health.go              # /healthz, /readyz
+│   │   └── middleware.go          # HTTP middleware chain
+│   ├── httputil/
+│   │   ├── clientip.go            # Client IP extraction
+│   │   ├── errormapper.go         # K8s error to HTTP status mapping
+│   │   └── problem.go             # RFC 7807 Problem Details
+│   ├── ka/
+│   │   ├── rest_client.go         # KA REST API client (autonomous flow)
+│   │   ├── mcp_client.go          # KA MCP client (interactive flow)
+│   │   ├── mcp_sdk_client.go      # KA MCP SDK client wrapper
+│   │   └── config.go              # KA client configuration
+│   ├── launcher/
+│   │   ├── launcher.go            # A2A task launcher (BeforeExecute/AfterExecute)
+│   │   └── model.go               # Launcher types
+│   ├── logging/
+│   │   └── logging.go             # logr/zap logger setup
+│   ├── metrics/
+│   │   └── metrics.go             # Prometheus metric registration (af_* prefix)
+│   ├── prometheus/
+│   │   ├── client.go              # HTTP client for /api/v1/{alerts,rules,query}
+│   │   ├── types.go               # Alert, RuleGroup, Rule, QueryResult types
+│   │   └── rules.go               # PromQL AST label extraction, resource matching
+│   ├── ratelimit/
+│   │   ├── ratelimit.go           # Per-user rate limiting (token bucket)
+│   │   └── config.go              # Rate limit configuration
+│   ├── requestid/
+│   │   ├── requestid.go           # Request ID generation
+│   │   └── transport.go           # Request ID HTTP transport
+│   ├── resilience/
+│   │   ├── circuitbreaker.go      # Generic circuit breaker
+│   │   ├── k8s_cb.go              # K8s-specific circuit breaker
+│   │   ├── k8s_dynamic.go         # Resilient dynamic client wrapper
+│   │   └── retry.go               # Retry with backoff
+│   ├── security/
+│   │   ├── redact.go              # Error/URL/path redaction
+│   │   └── sanitize.go            # Input sanitization
+│   ├── session/
+│   │   ├── service.go             # Session CRD CRUD operations
+│   │   ├── decorator.go           # SessionServiceDecorator (user context)
+│   │   ├── reinvoke.go            # Session reinvocation (LLM re-entry)
+│   │   ├── statemachine.go        # Session phase state machine
+│   │   └── trimming.go            # Tool result size trimming
+│   ├── severity/
+│   │   ├── triage.go              # Multi-tier severity triage orchestrator
+│   │   ├── types.go               # TriageInput, TriageResult, Source, severity utils
+│   │   ├── cache.go               # TTL-based rules cache (sync.RWMutex)
+│   │   └── llm.go                 # LLMTriager interface implementation
+│   ├── streaming/
+│   │   ├── sse.go                 # SSE event construction and delivery
+│   │   └── tracker.go             # SSE connection tracking
 │   ├── tools/
-│   │   ├── registry.go            # Tool registration
+│   │   ├── helpers.go             # Shared tool helpers (TrimSliceToFit, errors)
 │   │   ├── af_list_events.go      # K8s Events query
 │   │   ├── af_get_pods.go         # Pod status query
 │   │   ├── af_get_workloads.go    # Workload health query
 │   │   ├── af_resolve_owner.go    # Owner chain resolution
 │   │   ├── af_check_existing_rr.go # RR existence check (dedup)
-│   │   └── af_create_rr.go        # RemediationRequest creation
-│   ├── session/
-│   │   └── manager.go             # Session lifecycle (create, update, lookup)
-│   ├── ka/
-│   │   ├── rest_client.go         # KA REST API client (autonomous flow)
-│   │   └── mcp_client.go          # KA MCP client (interactive flow: takeover, message)
-│   ├── streaming/
-│   │   ├── sse.go                 # SSE event construction and delivery to client
-│   │   ├── ka_relay.go            # Subscribe to KA /stream SSE and relay to client
-│   │   └── crd_watcher.go         # Watch RR/AA/SP CRD transitions → SSE events
-│   ├── ratelimit/
-│   │   ├── request_rate.go        # Per-user request rate (token bucket)
-│   │   ├── concurrency.go         # Global LLM concurrency (semaphore)
-│   │   └── token_budget.go        # Per-user token budget
-│   ├── security/
-│   │   ├── sanitizer.go           # Input/output sanitization
-│   │   ├── validator.go           # Structured output validation
-│   │   └── anomaly.go             # Tool call anomaly detection
-│   ├── audit/
-│   │   └── emitter.go             # Audit event emission to DataStorage
-│   ├── dedup/
-│   │   └── lease.go               # K8s Lease-based deduplication
-│   ├── controller/
-│   │   └── session_cleanup.go     # InvestigationSession TTL controller
-│   ├── integration/               # Integration tests
-│   ├── conformance/               # Protocol conformance tests
-│   └── maturity/                   # Service maturity P0 checks
-├── pkg/
-│   └── metrics/
-│       └── metrics.go             # Prometheus metric registration
+│   │   ├── af_create_rr.go        # RemediationRequest creation
+│   │   ├── crd_tools.go           # CRD-based kubernaut tools
+│   │   ├── ka_tools.go            # KA proxy tools
+│   │   └── ds_tools.go            # DataStorage proxy tools
+│   └── validate/
+│       └── k8s.go                 # K8s name/namespace/label validation
 ├── config/
 │   ├── crd/bases/                 # Generated CRD YAML
 │   ├── rbac/                      # ClusterRole, ClusterRoleBinding
@@ -167,9 +213,13 @@ kubernaut-apifrontend/
 ├── charts/
 │   └── kubernaut-apifrontend/     # Helm chart (dev/test only)
 └── docs/
-    ├── design/                    # This document
-    ├── adr/                       # Architecture Decision Records
-    └── operations/                # Runbooks
+    ├── design/                    # Architecture, data flow, triage design docs
+    ├── adr/                       # Architecture Decision Records (ADR-001..021)
+    ├── security/                  # Audit catalog, RBAC, service boundary
+    ├── slo/                       # SLO definitions
+    ├── operations/                # Deployment guide, runbooks
+    ├── tests/                     # Per-issue test plans
+    └── development/               # Developer guide, TDD prompts
 ```
 
 ### Component Responsibilities
@@ -185,6 +235,7 @@ graph LR
         Orchestrator[LLM Orchestrator]
         ToolRegistry[Tool Registry]
         SessionManager[Session Manager]
+        SevTriager[Severity Triager]
     end
 
     subgraph infra_pkg [Infrastructure]
@@ -202,6 +253,9 @@ graph LR
     Orchestrator --> ToolRegistry
     Orchestrator --> Security
     ToolRegistry --> SessionManager
+    ToolRegistry --> SevTriager
+    SevTriager -->|/api/v1/*| Prom[Prometheus]
+    SevTriager -->|Tier 2.5/3| LLMProv[LLM Provider]
     SessionManager -->|CRD| K8s[K8s API]
     Orchestrator --> Audit
 ```
@@ -426,7 +480,9 @@ stateDiagram-v2
 | `/mcp` | POST | JSON-RPC method dispatch (tools/list, tools/call) |
 | `/mcp` | POST + `Accept: text/event-stream` | Streaming tool execution |
 
-**Registered tools (6 AF-internal):**
+**Registered tools (20 total: 6 AF-native + 14 kubernaut proxy):**
+
+AF-native tools (execute against K8s API directly):
 
 | Tool | Purpose | Data source |
 |------|---------|-------------|
@@ -435,7 +491,26 @@ stateDiagram-v2
 | `af_get_workloads` | Get Deployment/StatefulSet health | K8s API (impersonated) |
 | `af_resolve_owner` | Resolve owner chain to root | K8s API (impersonated) |
 | `af_check_existing_rr` | Check if RR already exists for resource (dedup) | K8s API (AF SA) |
-| `af_create_rr` | Create RemediationRequest | K8s API (AF SA) |
+| `af_create_rr` | Create RemediationRequest (with severity triage) | K8s API (AF SA) |
+
+kubernaut proxy tools (forwarded to KA REST/MCP or DataStorage):
+
+| Tool | Purpose | Backend |
+|------|---------|---------|
+| `kubernaut_list_remediations` | List active and recent remediations | KA REST |
+| `kubernaut_get_remediation` | Get remediation details | KA REST |
+| `kubernaut_submit_signal` | Submit signal to active remediation | KA REST |
+| `kubernaut_approve` | Approve a remediation action | KA REST |
+| `kubernaut_cancel_remediation` | Cancel active remediation | KA REST |
+| `kubernaut_watch` | Watch remediation state changes | KA REST |
+| `kubernaut_start_investigation` | Start investigation session | KA MCP |
+| `kubernaut_poll_investigation` | Poll investigation for updates | KA REST |
+| `kubernaut_select_workflow` | Select workflow for investigation | KA MCP |
+| `kubernaut_present_decision` | Present decision point to user | KA MCP |
+| `kubernaut_list_workflows` | List available workflows | KA REST |
+| `kubernaut_get_remediation_history` | Get remediation execution history | DS REST |
+| `kubernaut_get_effectiveness` | Get effectiveness metrics | DS REST |
+| `kubernaut_get_audit_trail` | Get audit trail for remediations | DS REST |
 
 ### A2A Protocol (v0.3.0, JSON-RPC 2.0)
 
@@ -554,7 +629,7 @@ AF ServiceAccount permissions:
 | `af_http_request_duration_seconds` | method, path, status | — | Implemented |
 | `af_tool_call_duration_seconds` | tool, type | P99 < 500ms (internal), < 2s (proxy) | Implemented |
 | `af_auth_duration_seconds` | result | P99 < 200ms | Implemented |
-| `af_triage_duration_seconds` | outcome | P95 < 15s | Planned (PR5) |
+| `af_severity_triage_duration_seconds` | tier | P95 < 5s (Tier 1-2), P95 < 15s (Tier 3) | Implemented (#92) |
 | `af_sse_connect_duration_seconds` | — | P99 < 1s | Planned (PR6) |
 | `af_ka_poll_duration_seconds` | endpoint | — | Planned (PR5) |
 
@@ -568,7 +643,8 @@ AF ServiceAccount permissions:
 | `af_llm_tokens_total` | direction, model | Implemented |
 | `af_rate_limit_rejections_total` | tier, reason | Implemented |
 | `af_audit_events_total` | type | Implemented |
-| `af_triage_total` | outcome | Planned (PR5) |
+| `af_severity_triage_total` | tier, severity | Implemented (#92) |
+| `af_severity_triage_errors_total` | tier, error_type | Implemented (#92) |
 
 **Gauges:**
 
@@ -586,14 +662,15 @@ AF ServiceAccount permissions:
 
 ### Audit Trail
 
-7-link forensic chain emitted to DataStorage:
+8-link forensic chain emitted to DataStorage:
 1. A2A request received (who, what, when)
 2. Triage started (session created)
 3. Tool call executed (which tool, params, result summary)
-4. RR created (fingerprint, severity, target)
-5. Investigation delegated (KA session ID)
-6. User decision (accept/reject/cancel)
-7. Session completed (outcome, duration)
+4. Severity triage completed/failed (tier, source, severity, duration) — see `SEVERITY_TRIAGE.md`
+5. RR created (fingerprint, severity, target, signalLabels)
+6. Investigation delegated (KA session ID)
+7. User decision (accept/reject/cancel)
+8. Session completed (outcome, duration)
 
 ---
 
@@ -877,8 +954,9 @@ East-west encryption satisfies SC-8 (Transmission Confidentiality and Integrity)
 
 ## References
 
-- GitHub Issues: #41-#56, #57-#71 (design comments)
-- ADRs: `docs/adr/ADR-001` through `ADR-012`
+- GitHub Issues: #41-#56, #57-#71 (design comments), #92 (severity triage)
+- ADRs: `docs/adr/ADR-001` through `ADR-021`
+- Design Documents: `SEVERITY_TRIAGE.md`, `DATA_FLOW.md`, `TOOL_EXECUTION_MODEL.md`, `CONTAINER_IMAGE.md`
 - kubernaut PROPOSAL-EXT-003 Appendix B (delegated authorization model)
 - MCP Spec: https://spec.modelcontextprotocol.io/specification/2025-03-26/
 - A2A Spec: https://google.github.io/A2A/specification/

--- a/docs/design/DATA_FLOW.md
+++ b/docs/design/DATA_FLOW.md
@@ -6,7 +6,7 @@
 graph TB
     subgraph External
         Agent[AI Agent / MCP Client]
-        Prom[Prometheus]
+        PromScrape[Prometheus<br/>metrics scrape]
     end
 
     subgraph kubernaut-apifrontend
@@ -14,6 +14,7 @@ graph TB
         Auth[Auth Middleware<br/>JWT + Impersonation]
         MCP[MCP Handler<br/>Streamable HTTP]
         Bridge[Tool Bridge<br/>RBAC + Dispatch]
+        Triager[Severity Triager]
         Metrics[Metrics :9090]
         Health[Health :8081]
         Audit[Audit Emitter]
@@ -23,6 +24,8 @@ graph TB
         KA[kubernaut-agent<br/>REST + MCP]
         DS[data-storage<br/>REST]
         K8s[Kubernetes API<br/>Dynamic Client]
+        PromAPI[Prometheus<br/>Query API]
+        LLMProv[LLM Provider<br/>Vertex AI]
     end
 
     Agent -->|POST /mcp| Router
@@ -32,8 +35,11 @@ graph TB
     Bridge -->|CRD tools| K8s
     Bridge -->|KA tools| KA
     Bridge -->|DS tools| DS
+    Bridge -->|af_create_rr| Triager
+    Triager -->|/api/v1/alerts,rules,query| PromAPI
+    Triager -->|Tier 2.5/3 fallback| LLMProv
     Bridge --> Audit
-    Prom -->|GET /metrics| Metrics
+    PromScrape -->|GET /metrics| Metrics
 ```
 
 ## Request Flow: MCP Tool Call
@@ -109,6 +115,8 @@ graph LR
 | Kubernetes API | Dynamic Client | Impersonation | Yes (K8s-specific) | No | 30s |
 | kubernaut-agent | REST + MCP | JWT forwarding | Yes | 2 retries, exp backoff | 30s |
 | data-storage | REST (ogen) | Service identity | Yes | 3 retries, exp backoff | 10s |
+| Prometheus | HTTP `/api/v1/*` | Bearer token (SA) | Planned | No | 30s |
+| LLM Provider (Vertex AI) | gRPC/HTTP | ADC | Yes | No | Configurable |
 
 ## Error Redaction
 

--- a/docs/design/SEVERITY_TRIAGE.md
+++ b/docs/design/SEVERITY_TRIAGE.md
@@ -1,0 +1,501 @@
+# Severity Triage Design Document
+
+**Version:** 1.0
+**Status:** Accepted
+**Last Updated:** 2026-05-10
+**Issue:** [#92](https://github.com/jordigilh/kubernaut-apifrontend/issues/92)
+**NIST Controls:** AU-2 (Auditable Events), AU-12 (Audit Record Generation), SI-4 (System Monitoring), SC-8 (Transmission Confidentiality)
+
+---
+
+## Table of Contents
+
+1. [Problem Statement](#1-problem-statement)
+2. [Architecture Overview](#2-architecture-overview)
+3. [Triage Pipeline](#3-triage-pipeline)
+4. [Component Design](#4-component-design)
+5. [Integration Points](#5-integration-points)
+6. [Configuration](#6-configuration)
+7. [Security Model](#7-security-model)
+8. [Observability](#8-observability)
+9. [Failure Modes and Degradation](#9-failure-modes-and-degradation)
+10. [Data Flow Diagram](#10-data-flow-diagram)
+11. [Decision Log](#11-decision-log)
+12. [Cross-References](#12-cross-references)
+
+---
+
+## 1. Problem Statement
+
+When a manual signal arrives (via `af_create_rr` or `kubernaut_submit_signal`) without a user-supplied severity, the API Frontend must determine severity before creating the `RemediationRequest` CRD. Without severity, the kubernaut pipeline cannot classify, prioritize, or route the remediation.
+
+### Goals
+
+- Derive severity deterministically from Prometheus alerting state when possible
+- Fall back to LLM classification when deterministic triage is inconclusive
+- Record the triage source for auditability (FedRAMP AU-2)
+- Degrade gracefully when Prometheus is unreachable
+- Never assume a default severity — all code paths must produce a justified result or fail
+
+### Non-Goals
+
+- Modifying the kubernaut CRD schema (severity is set via existing `spec.severity` field)
+- Deploying or managing Prometheus alerting rules (operator scope)
+- Replacing user-supplied severity (explicit severity always wins)
+
+---
+
+## 2. Architecture Overview
+
+The severity triage pipeline is a new subsystem within the API Frontend that sits between tool argument parsing and CRD creation. It queries Prometheus for real-time alerting state and falls back to LLM classification when alerts and rules are insufficient.
+
+```mermaid
+graph TB
+    subgraph af [kubernaut-apifrontend]
+        Tool[af_create_rr / kubernaut_submit_signal]
+        Triager[Severity Triager]
+        PromClient[Prometheus Client]
+        LLM[LLM Triager]
+        Cache[Rules Cache]
+    end
+
+    subgraph external [External]
+        Prometheus[Prometheus / Thanos]
+        LLMProvider[Claude Sonnet 4.6 - Vertex AI]
+    end
+
+    Tool -->|severity == ""| Triager
+    Tool -->|severity != ""| Skip[Bypass triage]
+    Triager --> PromClient
+    Triager --> LLM
+    Triager --> Cache
+    PromClient -->|/api/v1/alerts| Prometheus
+    PromClient -->|/api/v1/rules| Prometheus
+    PromClient -->|/api/v1/query| Prometheus
+    LLM --> LLMProvider
+    Cache -.->|TTL: 30s| PromClient
+```
+
+### Package Layout
+
+```
+internal/
+├── prometheus/
+│   ├── client.go          # HTTP client for /api/v1/{alerts,rules,query}
+│   ├── types.go           # Alert, RuleGroup, Rule, QueryResult, Sample
+│   └── rules.go           # ExtractLabelMatchers, MatchesResource (PromQL AST)
+├── severity/
+│   ├── triage.go          # Triager orchestrator (5-tier pipeline)
+│   ├── types.go           # TriageInput, TriageResult, Source, severity utils
+│   ├── cache.go           # RulesCache (TTL, sync.RWMutex)
+│   └── llm.go             # LLMTriager interface implementation
+```
+
+---
+
+## 3. Triage Pipeline
+
+The pipeline runs five tiers in order. Each tier is a deterministic checkpoint — the first tier that produces a result wins. If no tier produces a result, the pipeline returns an error.
+
+```mermaid
+flowchart TD
+    Start([Manual Signal<br/>severity == &quot;&quot;]) --> T1{Tier 1<br/>Firing Alerts}
+    T1 -->|Match found| R1([severity from alert<br/>source: firing_alert])
+    T1 -->|No match / error| T15{Tier 1.5<br/>Pending Alerts}
+    T15 -->|Match found| R15([severity from rule<br/>source: pending_alert])
+    T15 -->|No match / error| T2{Tier 2<br/>Rule Evaluation}
+    T2 -->|Data returned| R2([severity from rule<br/>source: rule_evaluation])
+    T2 -->|No data / error| T25{Tier 2.5<br/>LLM + Rule Context}
+    T25 -->|Matched rules exist| R25([severity from LLM<br/>source: llm_rule_informed])
+    T25 -->|No matched rules| T3{Tier 3<br/>Pure LLM}
+    T3 -->|Success| R3([severity from LLM<br/>source: llm_triage])
+    T3 -->|Failure| Err([Error returned<br/>triage failed])
+```
+
+### Tier Descriptions
+
+| Tier | Source | Mechanism | Latency |
+|------|--------|-----------|---------|
+| **1** | Prometheus `/api/v1/alerts` | Filter firing alerts by resource label overlap; pick highest severity | ~50ms |
+| **1.5** | Prometheus `/api/v1/rules` (cached) | Filter rules in `pending` state by PromQL label matcher overlap with resource labels | ~5ms (cached) |
+| **2** | Prometheus `/api/v1/query` | For `inactive` rules whose PromQL matchers overlap, evaluate the expression via instant query; if data returns, inherit rule severity | ~100ms per query |
+| **2.5** | LLM (rule-informed) | When Tier 2 rules matched but yielded no data, send rule definitions + resource context to the LLM for classification | ~2-5s |
+| **3** | LLM (pure fallback) | No rules covered the resource; LLM classifies from resource context alone | ~2-5s |
+
+### Severity Ordering
+
+When multiple alerts or rules match, the highest severity wins:
+
+```
+critical (5) > high (4) > medium (3) > low (2) > info (1)
+```
+
+### Invariants
+
+- **LLM is mandatory.** `NewTriager` panics if the `LLMTriager` is nil. The pipeline must guarantee a result or an explicit error — silent defaults are prohibited.
+- **User severity wins.** If `args.Severity != ""`, triage is skipped entirely.
+- **No user input in PromQL.** All PromQL expressions originate from Prometheus `/api/v1/rules` responses. User-supplied strings are never interpolated into queries.
+- **Context propagation.** Every tier checks `ctx.Err()` between executions and respects cancellation.
+
+---
+
+## 4. Component Design
+
+### 4.1 Prometheus Client (`internal/prometheus`)
+
+The client wraps three Prometheus HTTP API v1 endpoints. It follows the kubernaut `prometheusHTTPClient` pattern from `pkg/effectivenessmonitor/client/prometheus_http.go`.
+
+#### Interface
+
+```go
+type Client interface {
+    GetAlerts(ctx context.Context) ([]Alert, error)
+    GetRules(ctx context.Context) ([]RuleGroup, error)
+    InstantQuery(ctx context.Context, query string) (*QueryResult, error)
+}
+```
+
+#### Safety Measures
+
+| Measure | Implementation |
+|---------|---------------|
+| Response body limit | `io.LimitReader(resp.Body, 10MB)` |
+| Error redaction | All errors wrapped through `security.RedactError` before returning |
+| Context propagation | `http.NewRequestWithContext` on every request |
+| TLS support | Caller provides pre-configured `*http.Client` with CA and bearer token |
+
+### 4.2 PromQL Label Extraction (`internal/prometheus/rules.go`)
+
+Two functions extract label selectors from PromQL ASTs and match them against resource labels:
+
+- **`ExtractLabelMatchers(expr string)`** — Parses PromQL via `promql/parser`, walks the AST with `parser.Inspect`, collects `VectorSelector` label matchers (excluding `__name__`). Returns error for invalid PromQL — never panics.
+
+- **`MatchesResource(matchers, resourceLabels)`** — Returns `true` when all matchers are satisfied by the resource labels. Supports equality (`=`), inequality (`!=`), and regex (`=~`, `!~`) matchers via the `labels.Matcher.Matches()` method.
+
+### 4.3 Triager (`internal/severity/triage.go`)
+
+The orchestrator struct holds all dependencies:
+
+```go
+type Triager struct {
+    promClient prom.Client
+    llm        LLMTriager     // mandatory — panics if nil at construction
+    config     Config
+    logger     logr.Logger
+    cache      *RulesCache
+}
+```
+
+Each tier is implemented as a separate method (`runTier1`, `runTier15`, `runTier2`, `runTier25`, `runTier3`) called sequentially by `Triage()`.
+
+### 4.4 Rules Cache (`internal/severity/cache.go`)
+
+TTL-based cache for `/api/v1/rules` responses, shared between Tier 1.5 and Tier 2 within a single triage invocation and across invocations within the TTL window.
+
+| Property | Value |
+|----------|-------|
+| TTL | Configurable (default: 30s) |
+| Thread safety | `sync.RWMutex` |
+| Eviction | Lazy (checked on `Get()`) |
+| Growth bound | Single cached value (not a map) — no unbounded growth |
+| Copy semantics | `Get()` and `Set()` copy the slice to prevent mutation |
+
+### 4.5 LLM Triager (`internal/severity`)
+
+Interface for LLM-based severity classification:
+
+```go
+type LLMTriager interface {
+    TriageWithRules(ctx context.Context, rules []prom.Rule, input TriageInput) (TriageResult, error)
+    TriagePure(ctx context.Context, input TriageInput) (TriageResult, error)
+}
+```
+
+The prompt is constructed by `BuildTriagePrompt` which:
+- Includes resource context (namespace, kind, name, description)
+- Filters sensitive labels (password, token, secret, key, credential, bearer)
+- For Tier 2.5, includes matched rule names, expressions, annotations, and configured severity
+- Instructs the LLM to respond with exactly one of: `critical`, `high`, `medium`, `low`, `info`
+
+LLM responses are validated against the `validSeverities` allowlist and normalized (lowercased, trimmed).
+
+---
+
+## 5. Integration Points
+
+### 5.1 Tool Integration
+
+The triage pipeline is invoked from tool handlers when severity is empty:
+
+```
+af_create_rr(severity: "")
+    → Triager.Triage(ctx, TriageInput{namespace, kind, name, description, labels})
+    → TriageResult{Severity: "high", Source: "firing_alert", AlertName: "HighErrorRate"}
+    → RR spec.severity = "high"
+    → RR spec.signalLabels = {"severity_source": "firing_alert", "severity_alert_name": "HighErrorRate"}
+```
+
+### 5.2 Signal Labels
+
+Triage metadata is persisted on the RR CRD via `spec.signalLabels`:
+
+| Key | Value | When Set |
+|-----|-------|----------|
+| `severity_source` | `firing_alert`, `pending_alert`, `rule_evaluation`, `llm_rule_informed`, `llm_triage` | Always |
+| `severity_alert_name` | Alert name from Tier 1 | Tier 1 only |
+| `severity_rule_name` | Rule name from Tier 1.5/2/2.5 | Tier 1.5/2/2.5 only |
+
+### 5.3 Downstream Dependencies
+
+| Dependency | Protocol | Auth | Timeout |
+|-----------|----------|------|---------|
+| Prometheus | HTTP `/api/v1/*` | Bearer token (ServiceAccount) | 30s (configurable) |
+| LLM Provider | gRPC/HTTP (Vertex AI) | Application Default Credentials | Existing LLM timeout |
+| Kubernetes API | Dynamic Client | Impersonation / SA | Existing tool timeout |
+
+---
+
+## 6. Configuration
+
+New `SeverityTriage` section in the YAML config:
+
+```yaml
+severityTriage:
+  enabled: true
+  prometheusURL: "http://prometheus:9090"
+  cacheTTLSeconds: 30
+  maxQueriesPerCall: 10
+  maxRulesEvaluated: 100
+  llmConfidence: 0.7
+  prometheus:
+    tlsCaFile: ""                    # optional: custom CA for Prometheus TLS
+    bearerTokenFile: ""              # optional: /var/run/secrets/.../token
+```
+
+| Field | Default | Required | Purpose |
+|-------|---------|----------|---------|
+| `enabled` | `true` | No | Feature flag to disable triage entirely |
+| `prometheusURL` | — | Yes (when enabled) | Base URL for Prometheus API |
+| `cacheTTLSeconds` | `30` | No | TTL for `/api/v1/rules` cache |
+| `maxQueriesPerCall` | `10` | No | Max instant queries per triage invocation |
+| `maxRulesEvaluated` | `100` | No | Max inactive rules evaluated in Tier 2 |
+| `llmConfidence` | `0.7` | No | Minimum confidence threshold for LLM results |
+
+### Startup Validation
+
+- If `enabled=true` and `prometheusURL` is empty → startup error (fail-fast)
+- If `llmConfidence` is outside `[0.0, 1.0]` → startup error
+- If `LLMTriager` dependency is nil → panic at `NewTriager` construction
+
+---
+
+## 7. Security Model
+
+### 7.1 PromQL Injection Prevention
+
+All PromQL expressions originate from Prometheus `/api/v1/rules` responses (server-controlled). User input is never interpolated into query strings. The `ExtractLabelMatchers` function only reads the AST — it does not construct queries from user data.
+
+### 7.2 Error Redaction
+
+Prometheus HTTP errors may contain internal cluster URLs, IP addresses, or path information. All errors from the Prometheus client are wrapped through `security.RedactError` before being returned to callers or emitted in audit events. Redaction rules:
+
+| Pattern | Replacement |
+|---------|------------|
+| URLs (any scheme) | `[URL_REDACTED]` |
+| File paths | `[PATH_REDACTED]` |
+| Secrets in values | `[REDACTED]` |
+
+### 7.3 LLM Prompt Safety
+
+The `BuildTriagePrompt` function filters sensitive labels before including them in the LLM prompt. Labels with keys matching `password`, `token`, `secret`, `key`, `credential`, or `bearer` are excluded. Namespace, kind, and name are included by design — they are required for classification and are not considered PII in the kubernaut context.
+
+### 7.4 TLS and Authentication
+
+The Prometheus client supports:
+- **TLS CA file** — Custom CA certificate pool for mTLS environments (FedRAMP SC-8)
+- **Bearer token file** — ServiceAccount token for Prometheus authentication, read from the standard mount path
+
+### 7.5 FedRAMP Control Mapping
+
+| Control | Implementation |
+|---------|---------------|
+| AU-2 (Auditable Events) | `EventSeverityTriageCompleted` and `EventSeverityTriageFailed` audit events |
+| AU-12 (Audit Record Generation) | Triage result (tier, severity, source, duration) recorded in audit trail |
+| SC-8 (Transmission Confidentiality) | TLS CA support for Prometheus; east-west mTLS via service mesh |
+| SI-4 (System Monitoring) | `af_severity_triage_*` metrics; `ApifrontendSeverityTriageErrorRate` alert |
+| AC-6 (Least Privilege) | Prometheus queries use SA token; user impersonation not needed for read-only metrics |
+
+---
+
+## 8. Observability
+
+### 8.1 Metrics
+
+| Metric | Type | Labels | Purpose |
+|--------|------|--------|---------|
+| `af_severity_triage_total` | Counter | `tier`, `severity` | Triage completions by tier and result |
+| `af_severity_triage_duration_seconds` | Histogram | `tier` | Latency per tier execution |
+| `af_severity_triage_errors_total` | Counter | `tier`, `error_type` | Tier-level errors (HTTP, parse, timeout) |
+
+### 8.2 Audit Events
+
+| Event Type | NIST | Trigger | Detail Fields |
+|-----------|------|---------|---------------|
+| `severity.triage.completed` | AU-2, AU-12 | Triage produces a result | `tier`, `severity`, `source`, `duration_ms`, `alert_name`, `rule_name` |
+| `severity.triage.failed` | AU-2 | All tiers fail or LLM error | `error` (redacted), `tier` (last attempted) |
+
+### 8.3 Alerting Rules
+
+| Alert | Expression | Severity | For |
+|-------|-----------|----------|-----|
+| `ApifrontendSeverityTriageErrorRate` | `rate(af_severity_triage_errors_total[5m]) > 0.1` | warning | 5m |
+
+### 8.4 SLO Impact
+
+| SLO | Impact |
+|-----|--------|
+| SLO-3 (CRD tool p99 < 500ms) | Triage adds latency to `af_create_rr`. Tier 1 adds ~50ms. Tier 3 (LLM) adds 2-5s. Triage timeout is separate from tool timeout. |
+| SLO-6 (5xx rate < 0.1%) | LLM failure in Tier 3 returns an error to the caller. This is a deliberate fail-safe — not a silent degradation. |
+
+---
+
+## 9. Failure Modes and Degradation
+
+```mermaid
+flowchart TD
+    PromErr[Prometheus unreachable] --> Skip1[Skip Tier 1]
+    Skip1 --> Skip15[Skip Tier 1.5]
+    Skip15 --> Skip2[Skip Tier 2]
+    Skip2 --> T3LLM[Tier 3: Pure LLM]
+    T3LLM -->|Success| Result([Severity derived])
+    T3LLM -->|Failure| Error([Error returned to caller])
+
+    RuleFetch[Rules fetch fails] --> Skip15b[Skip Tier 1.5]
+    Skip15b --> Skip2b[Skip Tier 2]
+    Skip2b --> T3LLMb[Tier 3: Pure LLM]
+
+    LLMFail[LLM unavailable] --> Panic([Startup panic:<br/>LLMTriager required])
+    LLMErr[LLM call error in Tier 3] --> PropErr([Error propagated:<br/>tier 3 LLM triage failed])
+
+    CtxCancel[Context cancelled] --> RetErr([context.Canceled<br/>returned immediately])
+```
+
+### Degradation Matrix
+
+| Failure | Tier 1 | Tier 1.5 | Tier 2 | Tier 2.5 | Tier 3 | Outcome |
+|---------|--------|----------|--------|----------|--------|---------|
+| Prometheus down | Skip | Skip | Skip | Skip (no rules) | Execute | LLM result or error |
+| Rules fetch fails | OK | Skip | Skip | Skip (no rules) | Execute | LLM result or error |
+| Single query fails | OK | OK | Skip that rule | OK | Fallback | Best-effort from earlier tiers |
+| LLM nil at startup | — | — | — | — | — | **Panic** (fail-fast) |
+| LLM call error | OK | OK | OK | Log + continue | Error | **Error returned** |
+| Context cancelled | — | — | — | — | — | `context.Canceled` immediately |
+
+### Key Design Decision: No Silent Defaults
+
+The pipeline **never** silently defaults to a hardcoded severity. If the LLM triager is nil, the system panics at startup. If the LLM call fails at Tier 3 (the last resort), the error is propagated to the caller. This ensures that every severity value is justified and traceable.
+
+---
+
+## 10. Data Flow Diagram
+
+### Complete Triage Sequence
+
+```mermaid
+sequenceDiagram
+    participant Tool as af_create_rr
+    participant Triager as Severity Triager
+    participant Cache as Rules Cache
+    participant Prom as Prometheus
+    participant LLM as LLM Provider
+
+    Tool->>Triager: Triage(ctx, {ns, kind, name, labels})
+    
+    Note over Triager,Prom: Tier 1: Firing Alerts
+    Triager->>Prom: GET /api/v1/alerts
+    Prom-->>Triager: alerts[]
+    Triager->>Triager: Filter by label overlap + state=firing
+    alt Firing alert matches
+        Triager-->>Tool: {severity, source: firing_alert}
+    end
+
+    Note over Triager,Prom: Tier 1.5 + 2: Rules (cached)
+    Triager->>Cache: Get()
+    alt Cache miss
+        Cache-->>Triager: nil
+        Triager->>Prom: GET /api/v1/rules
+        Prom-->>Triager: ruleGroups[]
+        Triager->>Cache: Set(ruleGroups)
+    else Cache hit
+        Cache-->>Triager: ruleGroups[]
+    end
+
+    Note over Triager: Tier 1.5: Pending Rules
+    Triager->>Triager: Filter rules state=pending, match PromQL labels
+    alt Pending rule matches
+        Triager-->>Tool: {severity, source: pending_alert}
+    end
+
+    Note over Triager,Prom: Tier 2: Rule Evaluation
+    loop For each inactive matching rule (max 10 queries)
+        Triager->>Prom: GET /api/v1/query?query={rule.expr}
+        Prom-->>Triager: QueryResult
+        alt Data returned
+            Triager-->>Tool: {severity, source: rule_evaluation}
+        end
+    end
+
+    Note over Triager,LLM: Tier 2.5: LLM with Rule Context
+    alt Matched rules exist but no data
+        Triager->>LLM: TriageWithRules(rules, input)
+        LLM-->>Triager: {severity}
+        Triager-->>Tool: {severity, source: llm_rule_informed}
+    end
+
+    Note over Triager,LLM: Tier 3: Pure LLM
+    Triager->>LLM: TriagePure(input)
+    alt Success
+        LLM-->>Triager: {severity}
+        Triager-->>Tool: {severity, source: llm_triage}
+    else Error
+        LLM-->>Triager: error
+        Triager-->>Tool: error (propagated)
+    end
+```
+
+---
+
+## 11. Decision Log
+
+| ID | Decision | Rationale | Date |
+|----|----------|-----------|------|
+| DL-1 | LLM is mandatory (panic on nil) | Cannot assume severity — every value must be justified or the system must fail explicitly | 2026-05-10 |
+| DL-2 | No `SourceDefault` / hardcoded fallback | Silent defaults mask pipeline failures and produce unjustified severity values | 2026-05-10 |
+| DL-3 | PromQL from server only, never user input | Prevents PromQL injection; all expressions originate from Prometheus rule definitions | 2026-05-02 |
+| DL-4 | Lazy cache eviction (no background goroutine) | Avoids goroutine lifecycle complexity; TTL checked on read is sufficient for 30s window | 2026-05-02 |
+| DL-5 | `security.RedactError` on all Prometheus errors | Internal URLs and paths must not leak to callers or audit events (FedRAMP SC-8) | 2026-05-02 |
+| DL-6 | Sensitive label filtering in LLM prompt | Labels named `password`, `token`, `secret`, `key`, `credential`, `bearer` excluded from prompts | 2026-05-02 |
+| DL-7 | `signalLabels` map for triage metadata (not CRD schema change) | Avoids modifying the kubernaut RR CRD schema; flexible key-value storage | 2026-05-02 |
+| DL-8 | Tier 2 rate limited to 10 queries per invocation | Prevents one triage call from overwhelming Prometheus with hundreds of instant queries | 2026-05-02 |
+| DL-9 | Tier 3 LLM error propagated (not swallowed) | If the last resort fails, the caller must know — swallowing the error produces an empty result | 2026-05-10 |
+
+---
+
+## 12. Cross-References
+
+| Document | Relevance |
+|----------|-----------|
+| `docs/design/ARCHITECTURE.md` | System context, observability catalog, security model |
+| `docs/design/DATA_FLOW.md` | MCP tool call flow, error redaction model |
+| `docs/design/TOOL_EXECUTION_MODEL.md` | Input validation, output safety, deduplication |
+| `docs/security/AUDIT_EVENT_CATALOG.md` | New `severity.triage.*` events to be added |
+| `docs/slo/SLO_DEFINITIONS.md` | SLO-3 (CRD tool latency) impacted by triage |
+| `docs/tests/92/test_plan.md` | 86 test cases covering all tiers and edge cases |
+| `docs/adr/ADR-020-mcp-bridge-rbac-runtime.md` | RBAC enforcement model (runtime only) |
+| `docs/operations/runbooks/RB-AF-010.md` | Triage troubleshooting runbook (planned) |
+| kubernaut `DD-SEVERITY-001 v1.1` | Canonical severity values and determination model |
+| kubernaut `pkg/effectivenessmonitor/client/prometheus_http.go` | Reference Prometheus client pattern |
+
+---
+
+*Source files: `internal/prometheus/client.go`, `internal/prometheus/rules.go`, `internal/prometheus/types.go`, `internal/severity/triage.go`, `internal/severity/types.go`, `internal/severity/cache.go`*

--- a/docs/development/DEVELOPER_GUIDE.md
+++ b/docs/development/DEVELOPER_GUIDE.md
@@ -45,15 +45,18 @@ internal/
   httputil/               — RFC 7807, IP extraction
   ka/                     — KA REST + MCP SDK client
   launcher/               — A2A JSON-RPC handler (ADK executor)
-  logging/                — Zap + slog logger setup
-  metrics/                — Prometheus registry
+  logging/                — logr/zap logger setup
+  metrics/                — Prometheus registry (af_* prefix)
+  prometheus/             — Prometheus HTTP client (alerts, rules, query)
   ratelimit/              — Per-IP and per-user rate limiters
   requestid/              — X-Request-ID middleware
   resilience/             — Circuit breakers, retry transport
   security/               — Error redaction, input sanitization
   session/                — CRD session service (InvestigationSession)
+  severity/               — Multi-tier severity triage pipeline
   streaming/              — SSE connection tracker
-  tools/                  — MCP tool implementations
+  tools/                  — MCP tool implementations (6 AF-native + 14 kubernaut proxy)
+  validate/               — K8s name/namespace/label validation
 api/
   apifrontend/v1alpha1/   — CRD types (InvestigationSession)
   openapi/                — OpenAPI spec

--- a/docs/operations/production-deployment-guide.md
+++ b/docs/operations/production-deployment-guide.md
@@ -7,6 +7,7 @@
 - OIDC identity provider (Keycloak, Okta, or similar) configured
 - Kubernaut Agent (KA) and DataStorage (DS) services deployed
 - Prometheus Operator (for PrometheusRule CRD)
+- Prometheus instance reachable from AF pods (for severity triage — `/api/v1/alerts`, `/api/v1/rules`, `/api/v1/query`)
 
 ## Deployment Model
 
@@ -72,6 +73,17 @@ mcp:
 
 agentCard:
   url: "https://apifrontend.example.com"
+
+severityTriage:
+  enabled: true
+  prometheusURL: "http://prometheus-operated:9090"
+  cacheTTLSeconds: 30
+  maxQueriesPerCall: 10
+  maxRulesEvaluated: 100
+  llmConfidence: 0.7
+  # prometheus:
+  #   tlsCaFile: "/etc/pki/tls/certs/prometheus-ca.crt"
+  #   bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
 logging:
   level: "INFO"

--- a/docs/operations/runbooks/RB-AF-010.md
+++ b/docs/operations/runbooks/RB-AF-010.md
@@ -1,0 +1,120 @@
+# RB-AF-010: Severity Triage Troubleshooting
+
+**Alert:** `ApifrontendSeverityTriageErrorRate`
+**Severity:** warning
+**Service:** kubernaut-apifrontend
+**Packages:** `internal/severity/`, `internal/prometheus/`
+
+---
+
+## Symptoms
+
+- `af_severity_triage_errors_total` counter rising
+- `af_create_rr` or `kubernaut_submit_signal` returning errors when severity is not user-supplied
+- Audit events `severity.triage.failed` appearing in the audit trail
+- Users reporting "triage failed" errors when creating remediations without explicit severity
+
+## Triage Pipeline Overview
+
+The severity triage pipeline runs five tiers in order:
+
+```
+Tier 1: Prometheus /api/v1/alerts (firing alerts)
+  ↓ miss
+Tier 1.5: Prometheus /api/v1/rules (pending rules, cached)
+  ↓ miss
+Tier 2: Prometheus /api/v1/query (instant query per matching rule)
+  ↓ miss
+Tier 2.5: LLM with rule context
+  ↓ miss
+Tier 3: Pure LLM fallback
+  ↓ error → propagated to caller
+```
+
+## Diagnostic Steps
+
+### 1. Check which tier is failing
+
+```promql
+# Error breakdown by tier
+rate(af_severity_triage_errors_total[5m])
+```
+
+| Tier | Failure Meaning |
+|------|----------------|
+| 1 | Prometheus `/api/v1/alerts` unreachable or returning errors |
+| 1.5 | Prometheus `/api/v1/rules` unreachable (or cache miss + fetch failed) |
+| 2 | Prometheus `/api/v1/query` failing for instant queries |
+| 2.5 | LLM call with rule context failed |
+| 3 | LLM pure fallback failed — **this is the terminal error** |
+
+### 2. Check Prometheus connectivity
+
+```bash
+# From AF pod
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  http://prometheus:9090/api/v1/alerts
+```
+
+Expected: HTTP 200. If not:
+- Check network connectivity (NetworkPolicy, DNS)
+- Check bearer token validity
+- Check Prometheus health
+
+### 3. Check LLM connectivity
+
+If Tier 3 is failing, the LLM provider is unreachable:
+- Check Vertex AI credentials (Workload Identity, ADC)
+- Check GCP project/region configuration
+- Check LLM circuit breaker state: `af_circuit_breaker_state{dependency="llm"}`
+
+### 4. Check AF logs
+
+```bash
+kubectl logs -l app.kubernetes.io/name=kubernaut-apifrontend -c apifrontend | \
+  grep -E "Tier [0-9].*failed|LLM.*failed|triage"
+```
+
+Key log messages:
+- `"Tier 1 failed, continuing"` — Prometheus alerts API error (non-fatal)
+- `"skipping Tier 1.5: rules fetch failed"` — Rules fetch failed (non-fatal)
+- `"skipping Tier 2: rules fetch failed"` — Same as above
+- `"Tier 2 query failed"` — Individual instant query failed (non-fatal)
+- `"Tier 2.5 LLM failed"` — LLM with rule context failed (falls to Tier 3)
+- `"tier 3 LLM triage failed"` — Terminal error (propagated to caller)
+
+### 5. Check configuration
+
+```bash
+kubectl get configmap apifrontend-config -o yaml | grep -A 10 severityTriage
+```
+
+Verify:
+- `enabled: true`
+- `prometheusURL` is correct and reachable
+- `cacheTTLSeconds` is reasonable (default: 30)
+- `maxQueriesPerCall` is not set too low
+
+## Resolution
+
+| Root Cause | Fix |
+|-----------|-----|
+| Prometheus unreachable | Check NetworkPolicy, DNS, Service endpoints |
+| Prometheus returning 5xx | Check Prometheus health, disk space, memory |
+| Bearer token expired | Check projected volume mount, kubelet token rotation |
+| TLS certificate mismatch | Verify `prometheus.tlsCaFile` matches Prometheus server cert |
+| LLM provider down | Check Vertex AI status, credentials, circuit breaker state |
+| LLM rate limited | Check `MaxLLMConcurrency` configuration |
+| Config missing `prometheusURL` | AF won't start if triage is enabled without URL |
+
+## Escalation
+
+If both Prometheus and LLM are healthy but triage still fails:
+1. Check `af_severity_triage_duration_seconds` for timeouts
+2. Check for PromQL parsing errors in Tier 2 (may indicate rule format changes)
+3. Escalate to the kubernaut team with AF logs and `af_severity_triage_*` metric snapshots
+
+---
+
+*Related: `docs/design/SEVERITY_TRIAGE.md`, `docs/adr/ADR-021-severity-triage.md`*

--- a/docs/security/AUDIT_EVENT_CATALOG.md
+++ b/docs/security/AUDIT_EVENT_CATALOG.md
@@ -104,6 +104,17 @@ Events are delivered through the `audit.Emitter` interface. Two implementations 
 
 ---
 
+## Severity Triage
+
+| Event Type | Constant | NIST Control | Trigger | Detail Fields |
+|-----------|----------|-------------|---------|---------------|
+| `severity.triage.completed` | `EventSeverityTriageCompleted` | AU-2, AU-12 | Triage pipeline determines severity | `tier`, `severity`, `source`, `duration_ms`, `alert_name` (if Tier 1), `rule_name` (if Tier 1.5/2/2.5) |
+| `severity.triage.failed` | `EventSeverityTriageFailed` | AU-2 | All triage tiers fail or LLM error | `error` (redacted), `tier` (last attempted), `namespace`, `kind`, `name` |
+
+**Emitted from:** `internal/severity/triage.go` (via tool handler integration in `internal/tools/af_create_rr.go`)
+
+---
+
 ## Adding New Events
 
 1. Define the `EventType` constant in `internal/audit/audit.go`
@@ -113,4 +124,4 @@ Events are delivered through the `audit.Emitter` interface. Two implementations 
 
 ---
 
-*Last updated: 2026-05-08 | Covers v1.5 milestone (issues #52, #56)*
+*Last updated: 2026-05-10 | Covers v1.5 milestone (issues #52, #56, #92)*

--- a/docs/security/AUTHENTICATION_AND_RBAC.md
+++ b/docs/security/AUTHENTICATION_AND_RBAC.md
@@ -174,6 +174,22 @@ The Helm-managed ClusterRole grants the AF ServiceAccount:
 
 ---
 
+## 4.1 External Dependency Authentication: Prometheus
+
+The severity triage pipeline (`internal/severity/triage.go`) queries Prometheus via HTTP for alert and rule data. This uses **service identity** authentication, not end-user impersonation:
+
+| Property | Value |
+|----------|-------|
+| Client scope | AF ServiceAccount (not user impersonation) |
+| Auth mechanism | Bearer token from SA projected volume (`prometheus.bearerTokenFile`) |
+| TLS | Optional custom CA file (`prometheus.tlsCaFile`) for mTLS environments |
+| Rationale | Prometheus metrics/rules are cluster-wide data; user-scoped access is not applicable |
+| NIST | AC-6 (least privilege): AF only needs read access to `/api/v1/{alerts,rules,query}` |
+
+This is distinct from the K8s impersonation model used by triage tools (`af_list_events`, etc.) which operate on behalf of the calling user.
+
+---
+
 ## 5. Credential Lifecycle
 
 | Credential | Type | Rotation | Storage |

--- a/docs/security/SERVICE_BOUNDARY.md
+++ b/docs/security/SERVICE_BOUNDARY.md
@@ -32,6 +32,7 @@ graph TB
         K8sAPI[Kubernetes API Server]
         KA[Kubernaut Agent — REST/MCP]
         DS[Data Store API]
+        Prom[Prometheus — Query API]
         LLM[Vertex AI — Claude Sonnet 4.6]
     end
 
@@ -51,6 +52,7 @@ graph TB
     Agent -->|SA — AF scope| K8sAPI
     Agent -->|REST + JWT delegation| KA
     Agent -->|Audit events via REST| DS
+    Agent -->|/api/v1/alerts,rules,query| Prom
     Agent -->|LLM inference| LLM
 ```
 
@@ -90,6 +92,7 @@ All ingress enters through a single HTTP listener on the configured port (defaul
 | Kubernaut Agent (KA) REST | HTTPS | Custom `ka.Client` | JWT delegation (original user token) | `ka` CB |
 | Kubernaut Agent (KA) MCP | HTTPS | `ka.SDKMCPClient` | JWT delegation (`ContextJWTDelegationTransport`) | — |
 | Data Store (DS) | HTTPS | ogen-generated client | ServiceAccount context | `ds-rest` CB |
+| Prometheus (triage) | HTTP/HTTPS | `prometheus.Client` | Bearer token (SA projected volume) | Planned |
 | Vertex AI (LLM) | HTTPS | ADK genai client | GCP Workload Identity | — |
 
 ---
@@ -102,6 +105,7 @@ All ingress enters through a single HTTP listener on the configured port (defaul
 | AF → K8s API Server | mTLS (in-cluster) | SA projected token + cluster CA |
 | AF → KA REST | TLS 1.2+ | Cluster internal CA |
 | AF → DS REST | TLS 1.2+ | Cluster internal CA |
+| AF → Prometheus | TLS 1.2+ (optional, configurable CA) | Cluster internal CA or custom CA file |
 | AF → Vertex AI | TLS 1.3 | Google public CA |
 
 **Note:** Pod-to-pod communication within the cluster relies on the network CNI's encryption capabilities (e.g., WireGuard in Cilium) or service mesh mTLS if deployed. The AF itself terminates TLS at the Ingress controller level; the pod listens on plain HTTP internally.

--- a/docs/slo/SLO_DEFINITIONS.md
+++ b/docs/slo/SLO_DEFINITIONS.md
@@ -19,6 +19,8 @@ These SLOs are aspirational targets to be validated once the service is running 
 | SLO-5 | Authentication Latency (p99) | < 200ms | `af_auth_duration_seconds` | `histogram_quantile(0.99, rate(...[5m]))` |
 | SLO-6 | Availability (5xx rate) | < 0.1% | `af_http_requests_total{status=~"5.."}` | `sum(rate({status=~"5.."}[5m])) / sum(rate(total[5m]))` |
 | SLO-7 | Agent Card Response (p99) | < 50ms | `af_http_request_duration_seconds{path="/.well-known/agent-card.json"}` | `histogram_quantile(0.99, rate(...[5m]))` |
+| SLO-8 | Severity Triage (Tier 1-2, p95) | < 500ms | `af_severity_triage_duration_seconds{tier=~"1\|1.5\|2"}` | `histogram_quantile(0.95, rate(...[5m]))` |
+| SLO-9 | Severity Triage (Tier 3 LLM, p95) | < 15s | `af_severity_triage_duration_seconds{tier="3"}` | `histogram_quantile(0.95, rate(...[5m]))` |
 
 ## Histogram Bucket Alignment
 
@@ -66,6 +68,16 @@ Alerting rules are defined in `deploy/prometheus-rules.yaml`. Each alert is deri
 | `ApifrontendDependencyLatencyHigh` | Operational | Dep P95 > 2s for 5m | warning |
 | `ApifrontendRateLimitStorm` | Operational | Rejections > 10/s for 2m | warning |
 | `ApifrontendSSEConnectionsHigh` | Operational | Active SSE > 100 for 5m | warning |
+| `ApifrontendSeverityTriageErrorRate` | SLO-8/9 | Triage error rate > 10% for 5m | warning |
+
+### Triage Latency Impact on SLO-3 (CRD Tool p99)
+
+The `af_create_rr` tool path now includes severity triage when no severity is provided. This adds latency:
+- **Tier 1** (Prometheus `/api/v1/alerts`): ~50ms — within SLO-3 budget
+- **Tier 1.5/2** (cached rules + instant query): ~100-200ms — within SLO-3 budget
+- **Tier 2.5/3** (LLM fallback): 2-15s — **exceeds** SLO-3; measured separately by SLO-8/9
+
+When triage falls to LLM tiers, the tool call will exceed SLO-3's 500ms target. This is expected and tracked independently. The `af_severity_triage_duration_seconds` histogram isolates triage latency from the overall tool latency.
 
 ## Validation Plan
 

--- a/docs/tests/92/test_plan.md
+++ b/docs/tests/92/test_plan.md
@@ -14,12 +14,12 @@ This test plan validates the three-tier severity triage pipeline that determines
 
 ### 1.1 Scope
 
-- `pkg/prometheus/client.go` — HTTP client wrapping `/api/v1/alerts`, `/api/v1/rules`, `/api/v1/query`
-- `pkg/prometheus/rules.go` — Rule matching: parse PromQL AST, extract label selectors, filter by target resource
-- `pkg/severity/triage.go` — Orchestrator: runs Tier 1 -> 1.5 -> 2 -> 2.5 -> 3 pipeline
-- `pkg/severity/types.go` — `TriageResult`, `SeveritySource`, severity ordering
-- `pkg/severity/llm.go` — LLM triage for Tier 2.5 (rule-informed) and Tier 3 (pure fallback)
-- `pkg/severity/cache.go` — TTL-based cache for `/api/v1/rules` responses
+- `internal/prometheus/client.go` — HTTP client wrapping `/api/v1/alerts`, `/api/v1/rules`, `/api/v1/query`
+- `internal/prometheus/rules.go` — Rule matching: parse PromQL AST, extract label selectors, filter by target resource
+- `internal/severity/triage.go` — Orchestrator: runs Tier 1 -> 1.5 -> 2 -> 2.5 -> 3 pipeline
+- `internal/severity/types.go` — `TriageResult`, `Source`, severity ordering
+- `internal/severity/llm.go` — LLM triage for Tier 2.5 (rule-informed) and Tier 3 (pure fallback)
+- `internal/severity/cache.go` — TTL-based cache for `/api/v1/rules` responses
 - Integration with `internal/tools/af_create_rr.go` and `internal/tools/crd_tools.go`
 - `internal/config/config.go` — New `SeverityTriage` config section
 - `internal/metrics/metrics.go` — New `af_severity_triage_*` metrics
@@ -66,7 +66,7 @@ This test plan incorporates fixes for all 25 findings from the multi-dimensional
 |----|----------|---------|------------|
 | SEC-01 | FAIL | No audit event for severity triage decisions (FedRAMP AU-2 gap) | Add `EventSeverityTriageCompleted` and `EventSeverityTriageFailed` audit events with tier, source, severity, duration |
 | SEC-02 | FAIL | Prometheus query strings could contain injected PromQL if constructed from user input | All PromQL comes from `/api/v1/rules` responses (server-controlled); validate that no user input is interpolated into query strings. Add explicit guard. |
-| SEC-03 | FAIL | LLM responses not validated against severity enum — could produce arbitrary strings | Validate LLM output against `validSeverities` allowlist; reject and default to `"medium"` on mismatch |
+| SEC-03 | FAIL | LLM responses not validated against severity enum — could produce arbitrary strings | Validate LLM output against `validSeverities` allowlist; reject invalid responses via `NormalizeSeverity` (returns `"medium"` for invalid LLM strings only, not for pipeline failures) |
 | SEC-04 | FAIL | No TLS CA config for Prometheus client (FedRAMP SC-8) | Support `prometheus.tlsCaFile` in config; build `*tls.Config` with custom CA pool |
 | SEC-05 | WARN | Prometheus bearer token for ServiceAccount auth not specified | Support `prometheus.bearerTokenFile` (standard `/var/run/secrets/kubernetes.io/serviceaccount/token`) |
 | SEC-06 | WARN | LLM prompt could leak K8s resource names to external provider | Document that LLM receives namespace/kind/name by design (required for classification); redact any secrets/configmap data from events context |
@@ -95,7 +95,7 @@ This test plan incorporates fixes for all 25 findings from the multi-dimensional
 
 | ID | Severity | Finding | Resolution |
 |----|----------|---------|------------|
-| UX-01 | FAIL | `severity` is optional in `CreateRRArgs` but `validSeverities` rejects empty string — triage must populate before validation | Invoke triage before severity validation; if triage fails, default to `"medium"` (not `"unknown"`, which causes P3 misrouting) |
+| UX-01 | FAIL | `severity` is optional in `CreateRRArgs` but `validSeverities` rejects empty string — triage must populate before validation | Invoke triage before severity validation; if triage fails, propagate error to caller (no silent defaults per ADR-021) |
 | UX-02 | WARN | No user-visible indication of which tier determined severity | Return `severity_source` in tool response alongside severity |
 
 #### Supply Chain (SC)
@@ -129,7 +129,7 @@ This test plan incorporates fixes for all 25 findings from the multi-dimensional
 | `MatchesResource` | `internal/prometheus` | New |
 | `RulesCache` | `internal/severity` | New |
 | `Triager` | `internal/severity` | New |
-| `TriageResult` / `SeveritySource` | `internal/severity` | New |
+| `TriageResult` / `Source` | `internal/severity` | New |
 | `LLMTriager` | `internal/severity` | New |
 | `SeverityTriageConfig` | `internal/config` | Modified |
 | `HandleCreateRR` | `internal/tools` | Modified |
@@ -163,7 +163,7 @@ This test plan incorporates fixes for all 25 findings from the multi-dimensional
 | BAC-T-15 | Prometheus client supports TLS CA and bearer token auth | FedRAMP SC-8 | P1 |
 | BAC-T-16 | Errors from Prometheus are redacted before audit/client exposure | Security | P1 |
 | BAC-T-17 | User-supplied severity on `af_create_rr` bypasses triage entirely | UX | P0 |
-| BAC-T-18 | Triage failure defaults to `"medium"` severity (not `"unknown"`) | Product | P1 |
+| BAC-T-18 | Triage failure returns error to caller (no silent defaults); LLM is mandatory at startup (panic on nil) | Product / ADR-021 | P0 |
 
 ---
 
@@ -319,7 +319,7 @@ This test plan incorporates fixes for all 25 findings from the multi-dimensional
 | UT-AF-T-060 | `HandleCreateRR` populates `spec.signalLabels` with alert/rule name when available | BAC-T-07 | P0 |
 | UT-AF-T-061 | `HandleSubmitSignal` with empty severity invokes triage → SP has triage severity | BAC-T-01 | P0 |
 | UT-AF-T-062 | `HandleSubmitSignal` with user-supplied severity skips triage | BAC-T-17 | P0 |
-| UT-AF-T-063 | Triage failure in `HandleCreateRR` defaults to "medium" (not panic) | BAC-T-18 | P0 |
+| UT-AF-T-063 | Triage failure in `HandleCreateRR` propagates error to caller (no silent default) | BAC-T-18 | P0 |
 | UT-AF-T-064 | `af_severity_triage_total{tier="1",severity="critical"}` incremented on Tier 1 hit | BAC-T-09 | P0 |
 | UT-AF-T-065 | `af_severity_triage_total{tier="3",severity="medium"}` incremented on Tier 3 hit | BAC-T-09 | P0 |
 | UT-AF-T-066 | `af_severity_triage_duration_seconds{tier="1"}` observed on Tier 1 | BAC-T-09 | P0 |
@@ -346,7 +346,7 @@ This test plan incorporates fixes for all 25 findings from the multi-dimensional
 | UT-AF-T-082 | LLM returns empty string → defaults to "medium" | BAC-T-12 | P0 |
 | UT-AF-T-083 | LLM returns "CRITICAL" (wrong case) → normalized to "critical" | BAC-T-12 | P0 |
 | UT-AF-T-084 | Concurrent triage calls (10 goroutines) under -race | BAC-T-01 | P0 |
-| UT-AF-T-085 | Triage with nil Triager in config → graceful error, not panic | BAC-T-10 | P0 |
+| UT-AF-T-085 | NewTriager panics when LLMTriager is nil (fail-fast at startup per ADR-021) | BAC-T-18 | P0 |
 | UT-AF-T-086 | Triage with nil metrics → silently skipped, not panic | BAC-T-09 | P0 |
 
 ---
@@ -615,9 +615,9 @@ This test plan incorporates fixes for all 25 findings from the multi-dimensional
 - NEW: `docs/operations/runbooks/RB-AF-010.md` — Triage troubleshooting runbook
 
 **Design decisions:**
-- `HandleCreateRR` receives `Triager` as optional parameter (nil = skip triage)
+- `HandleCreateRR` receives `Triager` as required parameter
 - Triage invoked only when `args.Severity == ""` (BAC-T-17)
-- On triage failure: log error, default to `"medium"`, set `severity_source: "default_fallback"`
+- On triage failure: propagate error to caller (no silent defaults per ADR-021)
 - Metrics use existing registry pattern; new counters added to `Registry`
 - Audit events emitted via `audit.EmitFromContext` pattern
 

--- a/internal/severity/triage.go
+++ b/internal/severity/triage.go
@@ -2,6 +2,7 @@ package severity
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 
@@ -44,7 +45,11 @@ type Triager struct {
 }
 
 // NewTriager creates a new Triager instance.
+// Panics if llm is nil — the pipeline requires an LLM fallback to guarantee a result.
 func NewTriager(promClient prom.Client, llm LLMTriager, cfg Config, logger logr.Logger) *Triager {
+	if llm == nil {
+		panic("NewTriager: LLMTriager must not be nil — the triage pipeline requires an LLM fallback")
+	}
 	if logger.GetSink() == nil {
 		logger = logr.Discard()
 	}
@@ -103,7 +108,7 @@ func (t *Triager) Triage(ctx context.Context, input TriageInput) (TriageResult, 
 	}
 
 	// Tier 2.5: LLM with rule context (only if rules matched but data was empty)
-	if len(matchedRules) > 0 && t.llm != nil {
+	if len(matchedRules) > 0 {
 		result, done = t.runTier25(ctx, input, matchedRules)
 		if done {
 			return result, nil
@@ -111,11 +116,7 @@ func (t *Triager) Triage(ctx context.Context, input TriageInput) (TriageResult, 
 	}
 
 	// Tier 3: Pure LLM fallback
-	if t.llm != nil {
-		return t.runTier3(ctx, input)
-	}
-
-	return TriageResult{Severity: "medium", Source: SourceDefault}, nil
+	return t.runTier3(ctx, input)
 }
 
 func (t *Triager) runTier1(ctx context.Context, input TriageInput) (TriageResult, bool) {
@@ -243,8 +244,7 @@ func (t *Triager) runTier25(ctx context.Context, input TriageInput, matchedRules
 func (t *Triager) runTier3(ctx context.Context, input TriageInput) (TriageResult, error) {
 	result, err := t.llm.TriagePure(ctx, input)
 	if err != nil {
-		t.logger.Info("Tier 3 LLM failed", "error", err.Error())
-		return TriageResult{Severity: "medium", Source: SourceDefault}, nil
+		return TriageResult{}, fmt.Errorf("tier 3 LLM triage failed: %w", err)
 	}
 	result.Source = SourceLLMTriage
 	return result, nil

--- a/internal/severity/triage_test.go
+++ b/internal/severity/triage_test.go
@@ -415,6 +415,26 @@ var _ = Describe("Triage Orchestrator", func() {
 			Expect(result.Severity).To(BeEmpty())
 			Expect(result.Source).To(BeEmpty())
 		})
+
+		It("UT-AF-T-047: NewTriager panics when LLM is nil", func() {
+			Expect(func() {
+				severity.NewTriager(&mockPromClient{}, nil, defaultCfg, logr.Discard())
+			}).To(Panic())
+		})
+
+		It("UT-AF-T-048: Tier 3 LLM error propagates instead of defaulting", func() {
+			mockProm := &mockPromClient{
+				alerts:     []prom.Alert{},
+				ruleGroups: []prom.RuleGroup{},
+			}
+			llm := &mockLLM{
+				pureErr: errors.New("LLM unavailable"),
+			}
+			triager := severity.NewTriager(mockProm, llm, defaultCfg, logr.Discard())
+			_, err := triager.Triage(context.Background(), defaultInput)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("tier 3 LLM triage failed"))
+		})
 	})
 
 	Describe("Concurrency", func() {

--- a/internal/severity/types.go
+++ b/internal/severity/types.go
@@ -17,7 +17,6 @@ const (
 	SourceRuleEval      Source = "rule_evaluation"
 	SourceLLMRuleInform Source = "llm_rule_informed"
 	SourceLLMTriage     Source = "llm_triage"
-	SourceDefault       Source = "default_fallback"
 )
 
 // TriageInput holds the resource context for severity triage.


### PR DESCRIPTION
## Summary

- **Enforces mandatory LLM in triage pipeline** — `NewTriager` panics if `LLMTriager` is nil; Tier 3 LLM errors propagate instead of returning hardcoded "medium"; removes `SourceDefault` constant
- **Adds severity triage design document** (`docs/design/SEVERITY_TRIAGE.md`) covering 5-tier pipeline architecture, component design, integration points, security model (FedRAMP), observability, failure modes, and decision log
- **Adds ADR-021** documenting mandatory LLM, no silent defaults, PromQL server-only, and lazy cache eviction decisions
- **Adds RB-AF-010 runbook** for triage troubleshooting
- **Addresses 28 findings from technical documentation readiness audit** across ARCHITECTURE.md, DATA_FLOW.md, AUDIT_EVENT_CATALOG.md, SLO_DEFINITIONS.md, SERVICE_BOUNDARY.md, AUTH_AND_RBAC.md, production-deployment-guide.md, DEVELOPER_GUIDE.md, and test_plan.md

## Audit Findings Addressed

| Severity | Count |
|----------|-------|
| FAIL | 12 |
| WARN | 11 |
| INFO | 5 |

Key fixes:
- ARCHITECTURE.md package layout rebuilt to match actual `internal/` tree
- MCP tool count corrected from 6 to 20
- Prometheus added as egress dependency across DATA_FLOW, SERVICE_BOUNDARY, AUTH docs
- `af_severity_triage_*` metrics added to observability catalog
- SLO-8/9 added for triage latency with impact analysis on SLO-3
- Test plan updated: `pkg/` → `internal/`, `SeveritySource` → `Source`, no-default behavior per ADR-021

## Test plan

- [x] `go build ./...` passes
- [x] All 58 tests pass with `-race` (35 severity + 23 prometheus)
- [x] No code logic changes beyond mandatory LLM enforcement and silent default removal
- [x] 2 new tests: UT-AF-T-047 (panic on nil LLM), UT-AF-T-048 (Tier 3 error propagation)


Made with [Cursor](https://cursor.com)