### PR TITLE
feat: RC1 test hardening — security, coverage, adversarial, and token-expiry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
+      - name: Verify module checksums
+        run: go mod verify
+
       - name: Verify go.mod tidy
         run: |
           go mod tidy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,7 @@ jobs:
                        quay.io
 
       - name: Install Syft
-        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v1.20.0
 
       - name: Generate SBOM
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ dist/
 /apifrontend
 *.out
 sbom.cdx.json
+
+# Local environment / secrets
+*.env.local
+test-llm-*.env

--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,13 @@ validate-kustomize: ## Validate kustomize build for dev, ci, and e2e overlays
 	kubectl kustomize deploy/kustomize/overlays/e2e/ > /dev/null
 	@echo "Kustomize build validated for dev, ci, and e2e overlays"
 
+##@ Local LLM Testing
+
+.PHONY: test-llm-local
+test-llm-local: ## Run LLM integration tests locally (requires LLM_PROJECT, LLM_REGION env vars)
+	@echo "Running LLM integration tests (never runs in CI)..."
+	go test -v -count=1 --tags=llm_integration ./internal/severity/...
+
 ##@ Security & Supply Chain
 
 .PHONY: sbom

--- a/deploy/kustomize/base/05-prometheusrule.yaml
+++ b/deploy/kustomize/base/05-prometheusrule.yaml
@@ -234,7 +234,7 @@ spec:
           expr: |
             (sum(rate(af_rate_limit_rejections_total{job="apifrontend"}[5m])) > 5)
             and
-            (sum(rate(af_http_requests_total{job="apifrontend",code="401"}[5m])) > 5)
+            (sum(rate(af_http_requests_total{job="apifrontend",status="401"}[5m])) > 5)
           for: 5m
           labels:
             severity: critical

--- a/internal/auth/adversarial_jwt_test.go
+++ b/internal/auth/adversarial_jwt_test.go
@@ -1,0 +1,395 @@
+package auth_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut-apifrontend/internal/auth"
+)
+
+var _ = Describe("Adversarial OIDC", func() {
+	var (
+		kp      *testKeyPair
+		jwksSrv *httptest.Server
+		cfg     auth.Config
+	)
+
+	BeforeEach(func() {
+		kp = newTestKeyPair("adv-key-1")
+		jwksSrv = newJWKSServer(kp.jwks())
+		cfg = auth.Config{
+			JWT: []auth.ProviderConfig{
+				{
+					Issuer: auth.IssuerConfig{
+						URL:       jwksSrv.URL,
+						Audiences: []string{"kubernaut-agent"},
+					},
+				},
+			},
+		}
+	})
+
+	Describe("Cryptographic attacks", func() {
+		It("ADV-001: wrong signing key is rejected", func() {
+			// Business outcome: a token signed with an unknown key cannot authenticate
+			attackerKey := newTestKeyPair("attacker-key")
+			claims := standardClaims(jwksSrv.URL, "alice", []string{"kubernaut-agent"}, nil, time.Now().Add(time.Hour))
+			token := attackerKey.signToken(claims)
+
+			validator, err := auth.NewJWTValidator(cfg, auth.WithHTTPClient(jwksSrv.Client()))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = validator.Validate(context.Background(), token)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(auth.ErrMalformedToken))
+		})
+
+		It("ADV-002: alg:none token is rejected", func() {
+			// Business outcome: unsigned tokens cannot bypass authentication
+			claims := standardClaims(jwksSrv.URL, "alice", []string{"kubernaut-agent"}, nil, time.Now().Add(time.Hour))
+			payload, err := json.Marshal(claims)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Craft alg:none token manually (header.payload.)
+			header := `{"alg":"none","typ":"JWT"}`
+			token := base64url([]byte(header)) + "." + base64url(payload) + "."
+
+			validator, err := auth.NewJWTValidator(cfg, auth.WithHTTPClient(jwksSrv.Client()))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = validator.Validate(context.Background(), token)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("ADV-003: alg:HS256 symmetric confusion is rejected", func() {
+			// Business outcome: symmetric algorithms are not accepted (only RS256/ES256)
+			claims := standardClaims(jwksSrv.URL, "alice", []string{"kubernaut-agent"}, nil, time.Now().Add(time.Hour))
+			payload, err := json.Marshal(claims)
+			Expect(err).NotTo(HaveOccurred())
+
+			header := `{"alg":"HS256","typ":"JWT"}`
+			token := base64url([]byte(header)) + "." + base64url(payload) + ".fake-sig"
+
+			validator, err := auth.NewJWTValidator(cfg, auth.WithHTTPClient(jwksSrv.Client()))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = validator.Validate(context.Background(), token)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("ADV-004: ES256 token verifies correctly", func() {
+			// Business outcome: ECDSA-signed tokens work alongside RSA tokens
+			ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			Expect(err).NotTo(HaveOccurred())
+
+			ecJWKS := jose.JSONWebKeySet{
+				Keys: []jose.JSONWebKey{
+					{Key: &ecKey.PublicKey, KeyID: "ec-key-1", Algorithm: string(jose.ES256), Use: "sig"},
+				},
+			}
+			ecSrv := newJWKSServer(ecJWKS)
+
+			ecCfg := auth.Config{
+				JWT: []auth.ProviderConfig{
+					{Issuer: auth.IssuerConfig{URL: ecSrv.URL, Audiences: []string{"kubernaut-agent"}}},
+				},
+			}
+
+			signer, err := jose.NewSigner(
+				jose.SigningKey{Algorithm: jose.ES256, Key: ecKey},
+				(&jose.SignerOptions{}).WithHeader(jose.HeaderKey("kid"), "ec-key-1"),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			claims := standardClaims(ecSrv.URL, "alice", []string{"kubernaut-agent"}, nil, time.Now().Add(time.Hour))
+			raw, err := josejwt.Signed(signer).Claims(claims).Serialize()
+			Expect(err).NotTo(HaveOccurred())
+
+			validator, err := auth.NewJWTValidator(ecCfg, auth.WithHTTPClient(ecSrv.Client()))
+			Expect(err).NotTo(HaveOccurred())
+
+			identity, err := validator.Validate(context.Background(), raw)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(identity.Username).To(Equal("alice"))
+		})
+	})
+
+	Describe("Claim manipulation", func() {
+		It("ADV-005: issuer spoofing is rejected", func() {
+			// Business outcome: valid signature but wrong issuer cannot access a different provider's realm
+			claims := standardClaims("https://evil-issuer.example.com", "alice", []string{"kubernaut-agent"}, nil, time.Now().Add(time.Hour))
+			token := kp.signToken(claims)
+
+			validator, err := auth.NewJWTValidator(cfg, auth.WithHTTPClient(jwksSrv.Client()))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = validator.Validate(context.Background(), token)
+			Expect(err).To(MatchError(auth.ErrUnknownIssuer))
+		})
+
+		It("ADV-006: nbf in the future is rejected", func() {
+			// Business outcome: time-gated tokens cannot be used prematurely
+			claims := standardClaims(jwksSrv.URL, "alice", []string{"kubernaut-agent"}, nil, time.Now().Add(time.Hour))
+			claims["nbf"] = time.Now().Add(time.Hour).Unix()
+			token := kp.signToken(claims)
+
+			validator, err := auth.NewJWTValidator(cfg, auth.WithHTTPClient(jwksSrv.Client()))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = validator.Validate(context.Background(), token)
+			Expect(err).To(MatchError(auth.ErrNotYetValid))
+		})
+
+		It("ADV-007: audience array with extra entries still matches", func() {
+			// Business outcome: if any configured audience is present, token is accepted
+			claims := standardClaims(jwksSrv.URL, "alice", []string{"kubernaut-agent", "other-service"}, nil, time.Now().Add(time.Hour))
+			token := kp.signToken(claims)
+
+			validator, err := auth.NewJWTValidator(cfg, auth.WithHTTPClient(jwksSrv.Client()))
+			Expect(err).NotTo(HaveOccurred())
+
+			identity, err := validator.Validate(context.Background(), token)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(identity.Username).To(Equal("alice"))
+		})
+
+		It("ADV-008: single-string aud is accepted (RFC 7519 compat)", func() {
+			// Business outcome: RFC 7519 allows aud as a single string
+			claims := map[string]interface{}{
+				"iss":                jwksSrv.URL,
+				"sub":                "alice",
+				"aud":                "kubernaut-agent", // single string, not array
+				"exp":                time.Now().Add(time.Hour).Unix(),
+				"preferred_username": "alice",
+			}
+			token := kp.signToken(claims)
+
+			validator, err := auth.NewJWTValidator(cfg, auth.WithHTTPClient(jwksSrv.Client()))
+			Expect(err).NotTo(HaveOccurred())
+
+			identity, err := validator.Validate(context.Background(), token)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(identity.Username).To(Equal("alice"))
+		})
+
+		It("ADV-009: empty sub claim is handled gracefully", func() {
+			// Business outcome: tokens with empty/null sub use the claim value without panic
+			claims := map[string]interface{}{
+				"iss": jwksSrv.URL,
+				"sub": "",
+				"aud": []string{"kubernaut-agent"},
+				"exp": time.Now().Add(time.Hour).Unix(),
+			}
+			token := kp.signToken(claims)
+
+			validator, err := auth.NewJWTValidator(cfg, auth.WithHTTPClient(jwksSrv.Client()))
+			Expect(err).NotTo(HaveOccurred())
+
+			identity, err := validator.Validate(context.Background(), token)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(identity).NotTo(BeNil())
+		})
+
+		It("ADV-010: extremely long sub (>1KB) does not crash", func() {
+			// Business outcome: DoS via oversized claims is mitigated
+			longSub := strings.Repeat("a", 2048)
+			claims := standardClaims(jwksSrv.URL, longSub, []string{"kubernaut-agent"}, nil, time.Now().Add(time.Hour))
+			token := kp.signToken(claims)
+
+			validator, err := auth.NewJWTValidator(cfg, auth.WithHTTPClient(jwksSrv.Client()))
+			Expect(err).NotTo(HaveOccurred())
+
+			// Should not panic — may succeed or fail on sanitization
+			_, _ = validator.Validate(context.Background(), token)
+		})
+
+		It("ADV-011: groups with control characters are sanitized", func() {
+			// Business outcome: control characters in group names are stripped
+			// to prevent log injection and header corruption
+			claims := standardClaims(jwksSrv.URL, "alice", []string{"kubernaut-agent"},
+				[]string{"sre\r\nX-Injected: yes", "admin\x00root"}, time.Now().Add(time.Hour))
+			token := kp.signToken(claims)
+
+			validator, err := auth.NewJWTValidator(cfg, auth.WithHTTPClient(jwksSrv.Client()))
+			Expect(err).NotTo(HaveOccurred())
+
+			identity, err := validator.Validate(context.Background(), token)
+			Expect(err).NotTo(HaveOccurred())
+			for _, g := range identity.Groups {
+				Expect(g).NotTo(ContainSubstring("\r"))
+				Expect(g).NotTo(ContainSubstring("\n"))
+				Expect(g).NotTo(ContainSubstring("\x00"))
+			}
+		})
+
+		It("ADV-012: trailing garbage after base64 segments is rejected", func() {
+			// Business outcome: malformed tokens cannot bypass parsing
+			claims := standardClaims(jwksSrv.URL, "alice", []string{"kubernaut-agent"}, nil, time.Now().Add(time.Hour))
+			token := kp.signToken(claims) + "GARBAGE"
+
+			validator, err := auth.NewJWTValidator(cfg, auth.WithHTTPClient(jwksSrv.Client()))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = validator.Validate(context.Background(), token)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("Protocol/transport attacks", func() {
+		It("ADV-013: non-Bearer auth scheme is rejected by middleware", func() {
+			// Business outcome: only Bearer scheme is accepted
+			claims := standardClaims(jwksSrv.URL, "alice", []string{"kubernaut-agent"}, nil, time.Now().Add(time.Hour))
+			token := kp.signToken(claims)
+
+			validator, err := auth.NewJWTValidator(cfg, auth.WithHTTPClient(jwksSrv.Client()))
+			Expect(err).NotTo(HaveOccurred())
+
+			handler := auth.MiddlewareWithConfig(auth.MiddlewareConfig{Validator: validator})(
+				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(200) }))
+
+			schemes := []string{"Basic " + token, "bearer " + token, "MAC " + token, ""}
+			for _, scheme := range schemes {
+				req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+				if scheme != "" {
+					req.Header.Set("Authorization", scheme)
+				}
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+				Expect(rec.Code).To(BeNumerically(">=", 400),
+					"scheme %q should be rejected", scheme)
+			}
+		})
+
+		It("ADV-014: extremely long token (64KB) does not hang", func() {
+			// Business outcome: oversized tokens fail fast without resource exhaustion
+			longToken := strings.Repeat("eyJ", 21845) // ~64KB
+
+			validator, err := auth.NewJWTValidator(cfg, auth.WithHTTPClient(jwksSrv.Client()))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = validator.Validate(context.Background(), longToken)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("ADV-015: empty/whitespace token after Bearer is rejected", func() {
+			// Business outcome: whitespace-only tokens cannot bypass auth
+			validator, err := auth.NewJWTValidator(cfg, auth.WithHTTPClient(jwksSrv.Client()))
+			Expect(err).NotTo(HaveOccurred())
+
+			handler := auth.MiddlewareWithConfig(auth.MiddlewareConfig{Validator: validator})(
+				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(200) }))
+
+			tokens := []string{"Bearer ", "Bearer  ", "Bearer \t"}
+			for _, hdr := range tokens {
+				req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+				req.Header.Set("Authorization", hdr)
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+				Expect(rec.Code).To(Equal(http.StatusUnauthorized),
+					"header %q should be rejected", hdr)
+			}
+		})
+
+		It("ADV-016: duplicate kid across providers routes correctly", func() {
+			// Business outcome: key ID collision between providers doesn't cause cross-contamination
+			kp2 := newTestKeyPair("adv-key-1") // same kid as first provider
+			jwksSrv2 := newJWKSServer(kp2.jwks())
+
+			multiCfg := auth.Config{
+				JWT: []auth.ProviderConfig{
+					{Issuer: auth.IssuerConfig{URL: jwksSrv.URL, Audiences: []string{"kubernaut-agent"}}},
+					{Issuer: auth.IssuerConfig{URL: jwksSrv2.URL, Audiences: []string{"kubernaut-agent"}}},
+				},
+			}
+
+			validator, err := auth.NewJWTValidator(multiCfg, auth.WithHTTPClient(jwksSrv.Client()))
+			Expect(err).NotTo(HaveOccurred())
+
+			// Token from provider 1 should validate against provider 1's key
+			claims := standardClaims(jwksSrv.URL, "alice", []string{"kubernaut-agent"}, nil, time.Now().Add(time.Hour))
+			token := kp.signToken(claims)
+
+			identity, err := validator.Validate(context.Background(), token)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(identity.Username).To(Equal("alice"))
+
+			// Token from provider 2 signed with kp2's key
+			claims2 := standardClaims(jwksSrv2.URL, "bob", []string{"kubernaut-agent"}, nil, time.Now().Add(time.Hour))
+			token2 := kp2.signToken(claims2)
+
+			identity2, err := validator.Validate(context.Background(), token2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(identity2.Username).To(Equal("bob"))
+		})
+	})
+
+	Describe("Replay protection", func() {
+		It("ADV-017: replayed token with same jti is rejected", func() {
+			// Business outcome: token replay attacks are detected and blocked
+			rc := auth.NewReplayCache(1 * time.Minute)
+			DeferCleanup(rc.Stop)
+
+			validator, err := auth.NewJWTValidator(cfg,
+				auth.WithHTTPClient(jwksSrv.Client()),
+				auth.WithReplayCache(rc))
+			Expect(err).NotTo(HaveOccurred())
+
+			claims := standardClaims(jwksSrv.URL, "alice", []string{"kubernaut-agent"}, nil, time.Now().Add(time.Hour))
+			claims["jti"] = "unique-request-id-adv-017"
+			token := kp.signToken(claims)
+
+			identity, err := validator.Validate(context.Background(), token)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(identity.Username).To(Equal("alice"))
+
+			_, err = validator.Validate(context.Background(), token)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("ADV-018: replay protection is per-process only (documented limitation)", func() {
+			// Business outcome: separate validator instances have independent replay state
+			rc1 := auth.NewReplayCache(1 * time.Minute)
+			DeferCleanup(rc1.Stop)
+			rc2 := auth.NewReplayCache(1 * time.Minute)
+			DeferCleanup(rc2.Stop)
+
+			v1, err := auth.NewJWTValidator(cfg,
+				auth.WithHTTPClient(jwksSrv.Client()),
+				auth.WithReplayCache(rc1))
+			Expect(err).NotTo(HaveOccurred())
+
+			v2, err := auth.NewJWTValidator(cfg,
+				auth.WithHTTPClient(jwksSrv.Client()),
+				auth.WithReplayCache(rc2))
+			Expect(err).NotTo(HaveOccurred())
+
+			claims := standardClaims(jwksSrv.URL, "alice", []string{"kubernaut-agent"}, nil, time.Now().Add(time.Hour))
+			claims["jti"] = "cross-instance-jti"
+			token := kp.signToken(claims)
+
+			// Both validators accept the same token (no distributed cache)
+			_, err = v1.Validate(context.Background(), token)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = v2.Validate(context.Background(), token)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})
+
+// base64url encodes bytes without padding for crafting JWT segments.
+func base64url(data []byte) string {
+	return base64.RawURLEncoding.EncodeToString(data)
+}

--- a/internal/auth/config.go
+++ b/internal/auth/config.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -64,7 +65,24 @@ type KubernetesAuthConfig struct {
 // Validate checks the Config for structural errors.
 func (c *Config) Validate() error {
 	seen := make(map[string]struct{}, len(c.JWT))
-	for _, p := range c.JWT {
+	for i, p := range c.JWT {
+		if p.Issuer.URL == "" {
+			return fmt.Errorf("jwt[%d]: issuer URL must not be empty", i)
+		}
+		if len(p.Issuer.Audiences) == 0 {
+			return fmt.Errorf("jwt[%d]: audiences must not be empty (would reject all tokens)", i)
+		}
+		if p.Issuer.JWKSURL != "" {
+			u, err := url.Parse(p.Issuer.JWKSURL)
+			if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+				return fmt.Errorf("jwt[%d]: invalid JWKS URL %q (must be http or https)", i, p.Issuer.JWKSURL)
+			}
+		}
+		for j, rule := range p.UserValidationRules {
+			if rule.Expression == "" {
+				return fmt.Errorf("jwt[%d].userValidationRules[%d]: expression must not be empty", i, j)
+			}
+		}
 		if _, exists := seen[p.Issuer.URL]; exists {
 			return fmt.Errorf("duplicate issuer URL: %s", p.Issuer.URL)
 		}

--- a/internal/auth/config_test.go
+++ b/internal/auth/config_test.go
@@ -1,0 +1,142 @@
+package auth
+
+import (
+	"testing"
+)
+
+func TestConfig_Validate_RejectsEmptyIssuerURL(t *testing.T) {
+	cfg := &Config{
+		JWT: []ProviderConfig{
+			{
+				Issuer: IssuerConfig{
+					URL:       "",
+					Audiences: []string{"kubernaut-agent"},
+				},
+			},
+		},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for empty issuer URL")
+	}
+}
+
+func TestConfig_Validate_RejectsEmptyAudiences(t *testing.T) {
+	cfg := &Config{
+		JWT: []ProviderConfig{
+			{
+				Issuer: IssuerConfig{
+					URL:       "https://issuer.example.com",
+					Audiences: []string{},
+				},
+			},
+		},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for empty audiences (would reject all tokens)")
+	}
+}
+
+func TestConfig_Validate_RejectsNilAudiences(t *testing.T) {
+	cfg := &Config{
+		JWT: []ProviderConfig{
+			{
+				Issuer: IssuerConfig{
+					URL:       "https://issuer.example.com",
+					Audiences: nil,
+				},
+			},
+		},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for nil audiences")
+	}
+}
+
+func TestConfig_Validate_RejectsEmptyValidationExpression(t *testing.T) {
+	cfg := &Config{
+		JWT: []ProviderConfig{
+			{
+				Issuer: IssuerConfig{
+					URL:       "https://issuer.example.com",
+					Audiences: []string{"kubernaut-agent"},
+				},
+				UserValidationRules: []ValidationRule{
+					{Expression: "", Message: "rule with no expression"},
+				},
+			},
+		},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for empty expression in validation rule")
+	}
+}
+
+func TestConfig_Validate_RejectsMalformedJWKSURL(t *testing.T) {
+	cfg := &Config{
+		JWT: []ProviderConfig{
+			{
+				Issuer: IssuerConfig{
+					URL:       "https://issuer.example.com",
+					JWKSURL:   "not-a-valid-url",
+					Audiences: []string{"kubernaut-agent"},
+				},
+			},
+		},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for malformed JWKS URL")
+	}
+}
+
+func TestConfig_Validate_AcceptsValidJWKSURL(t *testing.T) {
+	cfg := &Config{
+		JWT: []ProviderConfig{
+			{
+				Issuer: IssuerConfig{
+					URL:       "https://issuer.example.com",
+					JWKSURL:   "https://issuer.example.com/.well-known/jwks.json",
+					Audiences: []string{"kubernaut-agent"},
+				},
+			},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected error for valid config: %v", err)
+	}
+}
+
+func TestConfig_Validate_AcceptsEmptyJWKSURL(t *testing.T) {
+	cfg := &Config{
+		JWT: []ProviderConfig{
+			{
+				Issuer: IssuerConfig{
+					URL:       "https://issuer.example.com",
+					JWKSURL:   "",
+					Audiences: []string{"kubernaut-agent"},
+				},
+			},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected error when JWKSURL is empty (should fall back to issuer URL): %v", err)
+	}
+}
+
+func TestConfig_Validate_AcceptsValidConfigWithRules(t *testing.T) {
+	cfg := &Config{
+		JWT: []ProviderConfig{
+			{
+				Issuer: IssuerConfig{
+					URL:       "https://issuer.example.com",
+					Audiences: []string{"kubernaut-agent"},
+				},
+				UserValidationRules: []ValidationRule{
+					{Expression: "!user.username.startsWith('system:')", Message: "no system users"},
+				},
+			},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected error for valid config with rules: %v", err)
+	}
+}

--- a/internal/auth/jwks_cache.go
+++ b/internal/auth/jwks_cache.go
@@ -28,11 +28,12 @@ func NewCircuitBreakerStateGauge() *prometheus.GaugeVec {
 // Fail-open for existing sessions (cached keys available), fail-closed for new sessions.
 // CK-04: maxStaleness caps how long cached keys remain valid without refresh.
 type JWKSCache struct {
-	mu           sync.RWMutex
-	entries      map[string]*jwksCacheEntry
-	client       *http.Client
-	maxStaleness time.Duration
-	breakers     map[string]*gobreaker.CircuitBreaker[*jose.JSONWebKeySet]
+	mu              sync.RWMutex
+	entries         map[string]*jwksCacheEntry
+	client          *http.Client
+	maxStaleness    time.Duration
+	refreshInterval time.Duration
+	breakers        map[string]*gobreaker.CircuitBreaker[*jose.JSONWebKeySet]
 }
 
 type jwksCacheEntry struct {
@@ -44,9 +45,10 @@ type jwksCacheEntry struct {
 type JWKSCacheOption func(*jwksCacheConfig)
 
 type jwksCacheConfig struct {
-	cbTimeout    time.Duration
-	cbGauge      *prometheus.GaugeVec
-	maxStaleness time.Duration
+	cbTimeout       time.Duration
+	cbGauge         *prometheus.GaugeVec
+	maxStaleness    time.Duration
+	refreshInterval time.Duration
 }
 
 // WithCBTimeout sets the circuit breaker half-open timeout. Default is 30s.
@@ -65,22 +67,30 @@ func WithMaxStaleness(d time.Duration) JWKSCacheOption {
 	return func(c *jwksCacheConfig) { c.maxStaleness = d }
 }
 
+// WithRefreshInterval sets the minimum time between successful JWKS fetches.
+// If cached keys are younger than this, GetKeys returns them without a network call.
+// Default: 5 minutes.
+func WithRefreshInterval(d time.Duration) JWKSCacheOption {
+	return func(c *jwksCacheConfig) { c.refreshInterval = d }
+}
+
 // NewJWKSCache creates a JWKS cache with circuit breakers per JWKS endpoint.
 func NewJWKSCache(client *http.Client, jwksURLs []string, opts ...JWKSCacheOption) *JWKSCache {
 	if client == nil {
 		client = &http.Client{Timeout: 10 * time.Second}
 	}
 
-	cfg := &jwksCacheConfig{cbTimeout: 30 * time.Second, maxStaleness: time.Hour}
+	cfg := &jwksCacheConfig{cbTimeout: 30 * time.Second, maxStaleness: time.Hour, refreshInterval: 5 * time.Minute}
 	for _, opt := range opts {
 		opt(cfg)
 	}
 
 	cache := &JWKSCache{
-		entries:      make(map[string]*jwksCacheEntry, len(jwksURLs)),
-		client:       client,
-		maxStaleness: cfg.maxStaleness,
-		breakers:     make(map[string]*gobreaker.CircuitBreaker[*jose.JSONWebKeySet], len(jwksURLs)),
+		entries:         make(map[string]*jwksCacheEntry, len(jwksURLs)),
+		client:          client,
+		maxStaleness:    cfg.maxStaleness,
+		refreshInterval: cfg.refreshInterval,
+		breakers:        make(map[string]*gobreaker.CircuitBreaker[*jose.JSONWebKeySet], len(jwksURLs)),
 	}
 
 	for _, jwksURL := range jwksURLs {
@@ -112,6 +122,16 @@ func (c *JWKSCache) GetKeys(ctx context.Context, issuerURL string) (*jose.JSONWe
 	cb, ok := c.breakers[issuerURL]
 	if !ok {
 		return nil, fmt.Errorf("no circuit breaker configured for issuer: %s", issuerURL)
+	}
+
+	// Return cached keys if still fresh (skip network round-trip)
+	if c.refreshInterval > 0 {
+		c.mu.RLock()
+		entry, hasCached := c.entries[issuerURL]
+		c.mu.RUnlock()
+		if hasCached && entry.keys != nil && time.Since(entry.fetchedAt) < c.refreshInterval {
+			return entry.keys, nil
+		}
 	}
 
 	result, err := cb.Execute(func() (*jose.JSONWebKeySet, error) {

--- a/internal/auth/jwks_cache_test.go
+++ b/internal/auth/jwks_cache_test.go
@@ -1,12 +1,30 @@
 package auth
 
 import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+func testJWKS(t *testing.T) jose.JSONWebKeySet {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{{Key: &key.PublicKey, KeyID: "test-key", Algorithm: "RS256", Use: "sig"}},
+	}
+}
 
 func TestNewCircuitBreakerStateGauge(t *testing.T) {
 	g := NewCircuitBreakerStateGauge()
@@ -54,5 +72,88 @@ func TestNewJWKSCache_RegistersCBGaugeStateChange(t *testing.T) {
 	}
 	if _, ok := cache.breakers["iss1"]; !ok {
 		t.Error("expected breaker registered for iss1")
+	}
+}
+
+func TestWithRefreshInterval(t *testing.T) {
+	cache := NewJWKSCache(nil, []string{"iss1"}, WithRefreshInterval(10*time.Minute))
+	if cache.refreshInterval != 10*time.Minute {
+		t.Errorf("expected refreshInterval=10m, got %v", cache.refreshInterval)
+	}
+}
+
+func TestJWKSCache_GetKeys_SkipsFetchWhenFresh(t *testing.T) {
+	// Business outcome: if JWKS was fetched recently (within refreshInterval),
+	// GetKeys returns cached keys WITHOUT hitting the network.
+	var fetchCount atomic.Int32
+	keySet := testJWKS(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fetchCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(keySet)
+	}))
+	defer srv.Close()
+
+	cache := NewJWKSCache(&http.Client{}, []string{srv.URL}, WithRefreshInterval(5*time.Minute))
+	ctx := context.Background()
+
+	// First call: must fetch
+	keys1, err := cache.GetKeys(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("first GetKeys: %v", err)
+	}
+	if keys1 == nil || len(keys1.Keys) == 0 {
+		t.Fatal("expected non-empty keys on first fetch")
+	}
+	if fetchCount.Load() != 1 {
+		t.Fatalf("expected 1 fetch, got %d", fetchCount.Load())
+	}
+
+	// Second call: should return cached (no new fetch)
+	keys2, err := cache.GetKeys(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("second GetKeys: %v", err)
+	}
+	if keys2 == nil || len(keys2.Keys) == 0 {
+		t.Fatal("expected non-empty keys on cached return")
+	}
+	if fetchCount.Load() != 1 {
+		t.Fatalf("expected still 1 fetch (cached), got %d", fetchCount.Load())
+	}
+}
+
+func TestJWKSCache_GetKeys_RefetchesAfterTTLExpires(t *testing.T) {
+	// Business outcome: after refreshInterval expires, a new fetch is performed.
+	var fetchCount atomic.Int32
+	keySet := testJWKS(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fetchCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(keySet)
+	}))
+	defer srv.Close()
+
+	// Use very short refresh interval so it expires immediately
+	cache := NewJWKSCache(&http.Client{}, []string{srv.URL}, WithRefreshInterval(1*time.Millisecond))
+	ctx := context.Background()
+
+	// First fetch
+	_, err := cache.GetKeys(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("first GetKeys: %v", err)
+	}
+
+	// Wait for TTL to expire
+	time.Sleep(5 * time.Millisecond)
+
+	// Should re-fetch
+	_, err = cache.GetKeys(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("second GetKeys: %v", err)
+	}
+	if fetchCount.Load() != 2 {
+		t.Fatalf("expected 2 fetches after TTL expiry, got %d", fetchCount.Load())
 	}
 }

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -182,6 +182,10 @@ func (v *JWTValidator) Validate(ctx context.Context, rawToken string) (*UserIden
 		return nil, err
 	}
 
+	if err := validateNotBefore(claims); err != nil {
+		return nil, err
+	}
+
 	if err := validateAudience(claims, provider.config.Issuer.Audiences); err != nil {
 		return nil, err
 	}
@@ -248,6 +252,9 @@ func verifySignature(token *josejwt.JSONWebToken, keySet *jose.JSONWebKeySet) (m
 // ErrMissingExpiry is returned when a token has no exp claim.
 var ErrMissingExpiry = errors.New("token missing required exp claim")
 
+// ErrNotYetValid is returned when a token's nbf claim is in the future.
+var ErrNotYetValid = errors.New("token not yet valid")
+
 func validateExpiry(claims map[string]interface{}) error {
 	raw, ok := claims["exp"]
 	if !ok {
@@ -259,6 +266,21 @@ func validateExpiry(claims map[string]interface{}) error {
 	}
 	if time.Unix(int64(exp), 0).Before(time.Now()) {
 		return ErrTokenExpired
+	}
+	return nil
+}
+
+func validateNotBefore(claims map[string]interface{}) error {
+	raw, ok := claims["nbf"]
+	if !ok {
+		return nil // nbf is optional per RFC 7519
+	}
+	nbf, ok := raw.(float64)
+	if !ok {
+		return nil // non-numeric nbf ignored (lenient)
+	}
+	if time.Now().Before(time.Unix(int64(nbf), 0)) {
+		return ErrNotYetValid
 	}
 	return nil
 }
@@ -297,12 +319,16 @@ func buildIdentity(claims map[string]interface{}, issuer, rawToken string) *User
 	if username == "" {
 		username = extractStringClaim(claims, "sub")
 	}
-	return &UserIdentity{
+	identity := &UserIdentity{
 		Username: security.SanitizeClaimValue(username),
 		Groups:   sanitizeGroups(extractGroupsClaim(claims)),
 		Issuer:   issuer,
 		RawToken: rawToken,
 	}
+	if exp, ok := claims["exp"].(float64); ok {
+		identity.ExpiresAt = time.Unix(int64(exp), 0)
+	}
+	return identity
 }
 
 func sanitizeGroups(groups []string) []string {

--- a/internal/auth/jwt_delegation.go
+++ b/internal/auth/jwt_delegation.go
@@ -1,6 +1,13 @@
 package auth
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// ErrTokenExpiredDelegation is returned when outbound delegation is attempted with an expired token.
+var ErrTokenExpiredDelegation = fmt.Errorf("token expired: refusing outbound delegation")
 
 // ContextJWTDelegationTransport wraps an http.RoundTripper to inject the
 // authenticated user's JWT from request context into outbound requests.
@@ -12,13 +19,19 @@ type ContextJWTDelegationTransport struct {
 }
 
 // RoundTrip extracts the raw JWT token from the request context (stored by
-// auth middleware) and sets it as the Authorization header. If no token is
-// found in context, the request is forwarded without modification.
+// auth middleware) and sets it as the Authorization header. If the token has
+// expired, the request is rejected (fail-closed) to prevent forwarding
+// invalid credentials.
 func (t *ContextJWTDelegationTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	identity := UserIdentityFromContext(req.Context())
-	if identity != nil && identity.RawToken != "" {
-		req = req.Clone(req.Context())
-		req.Header.Set("Authorization", "Bearer "+identity.RawToken)
+	if identity != nil {
+		if !identity.ExpiresAt.IsZero() && time.Now().After(identity.ExpiresAt) {
+			return nil, ErrTokenExpiredDelegation
+		}
+		if identity.RawToken != "" {
+			req = req.Clone(req.Context())
+			req.Header.Set("Authorization", "Bearer "+identity.RawToken)
+		}
 	}
 
 	base := t.Base

--- a/internal/auth/jwt_delegation_test.go
+++ b/internal/auth/jwt_delegation_test.go
@@ -5,10 +5,16 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/jordigilh/kubernaut-apifrontend/internal/auth"
 )
+
+func containsSubstring(s, sub string) bool {
+	return strings.Contains(s, sub)
+}
 
 func TestContextJWTDelegationTransport_SetsHeader(t *testing.T) {
 	var capturedHeader string
@@ -131,5 +137,58 @@ func TestContextJWTDelegationTransport_DoesNotMutateOriginalRequest(t *testing.T
 
 	if req.Header.Get("Authorization") != originalAuth {
 		t.Error("original request was mutated (Authorization header changed)")
+	}
+}
+
+func TestContextJWTDelegationTransport_RejectsExpiredToken(t *testing.T) {
+	// Business outcome: outbound requests with expired tokens fail closed
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("request should never reach backend")
+	}))
+	defer srv.Close()
+
+	transport := &auth.ContextJWTDelegationTransport{Base: http.DefaultTransport}
+	client := &http.Client{Transport: transport}
+
+	ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+		Username:  "alice",
+		RawToken:  "expired-token",
+		ExpiresAt: time.Now().Add(-time.Hour), // expired 1h ago
+	})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, http.NoBody)
+	_, err := client.Do(req)
+	if err == nil {
+		t.Fatal("expected error for expired token delegation")
+	}
+	if !containsSubstring(err.Error(), "token expired") {
+		t.Errorf("expected 'token expired' in error, got %v", err)
+	}
+}
+
+func TestContextJWTDelegationTransport_AllowsValidToken(t *testing.T) {
+	// Business outcome: tokens that haven't expired are forwarded normally
+	var capturedHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedHeader = r.Header.Get("Authorization")
+	}))
+	defer srv.Close()
+
+	transport := &auth.ContextJWTDelegationTransport{Base: http.DefaultTransport}
+	client := &http.Client{Transport: transport}
+
+	ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+		Username:  "alice",
+		RawToken:  "valid-token",
+		ExpiresAt: time.Now().Add(time.Hour), // valid for 1h
+	})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, http.NoBody)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	if capturedHeader != "Bearer valid-token" {
+		t.Errorf("Authorization = %q, want %q", capturedHeader, "Bearer valid-token")
 	}
 }

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -221,6 +221,90 @@ var _ = Describe("Auth", func() {
 				Expect(err).To(MatchError(auth.ErrMissingExpiry))
 			})
 
+			It("UT-AF-002-022: token with nbf in the future is rejected", func() {
+				kp := newTestKeyPair("key-1")
+				jwksSrv := newJWKSServer(kp.jwks())
+
+				cfg := auth.Config{
+					JWT: []auth.ProviderConfig{
+						{
+							Issuer: auth.IssuerConfig{
+								URL:       jwksSrv.URL,
+								Audiences: []string{"kubernaut-agent"},
+							},
+						},
+					},
+				}
+
+				validator, err := auth.NewJWTValidator(cfg, auth.WithHTTPClient(jwksSrv.Client()))
+				Expect(err).NotTo(HaveOccurred())
+
+				claims := standardClaims(jwksSrv.URL, "alice", []string{"kubernaut-agent"}, nil, time.Now().Add(time.Hour))
+				claims["nbf"] = time.Now().Add(time.Hour).Unix() // not valid until 1h from now
+
+				token := kp.signToken(claims)
+
+				_, err = validator.Validate(context.Background(), token)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(auth.ErrNotYetValid))
+			})
+
+			It("UT-AF-002-023: token with nbf in the past is accepted", func() {
+				kp := newTestKeyPair("key-1")
+				jwksSrv := newJWKSServer(kp.jwks())
+
+				cfg := auth.Config{
+					JWT: []auth.ProviderConfig{
+						{
+							Issuer: auth.IssuerConfig{
+								URL:       jwksSrv.URL,
+								Audiences: []string{"kubernaut-agent"},
+							},
+						},
+					},
+				}
+
+				validator, err := auth.NewJWTValidator(cfg, auth.WithHTTPClient(jwksSrv.Client()))
+				Expect(err).NotTo(HaveOccurred())
+
+				claims := standardClaims(jwksSrv.URL, "alice", []string{"kubernaut-agent"}, nil, time.Now().Add(time.Hour))
+				claims["nbf"] = time.Now().Add(-time.Minute).Unix() // valid since 1m ago
+
+				token := kp.signToken(claims)
+
+				identity, err := validator.Validate(context.Background(), token)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(identity.Username).To(Equal("alice"))
+			})
+
+			It("UT-AF-002-024: token without nbf claim is accepted (optional per RFC 7519)", func() {
+				kp := newTestKeyPair("key-1")
+				jwksSrv := newJWKSServer(kp.jwks())
+
+				cfg := auth.Config{
+					JWT: []auth.ProviderConfig{
+						{
+							Issuer: auth.IssuerConfig{
+								URL:       jwksSrv.URL,
+								Audiences: []string{"kubernaut-agent"},
+							},
+						},
+					},
+				}
+
+				validator, err := auth.NewJWTValidator(cfg, auth.WithHTTPClient(jwksSrv.Client()))
+				Expect(err).NotTo(HaveOccurred())
+
+				// standardClaims does not include nbf
+				claims := standardClaims(jwksSrv.URL, "alice", []string{"kubernaut-agent"}, nil, time.Now().Add(time.Hour))
+
+				token := kp.signToken(claims)
+
+				identity, err := validator.Validate(context.Background(), token)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(identity.Username).To(Equal("alice"))
+			})
+
 			It("UT-AF-002-003: wrong audience returns invalid audience error", func() {
 				kp := newTestKeyPair("key-1")
 				jwksSrv := newJWKSServer(kp.jwks())
@@ -326,10 +410,10 @@ var _ = Describe("Auth", func() {
 				cfg := auth.Config{
 					JWT: []auth.ProviderConfig{
 						{
-							Issuer: auth.IssuerConfig{URL: "https://sso.example.com"},
+							Issuer: auth.IssuerConfig{URL: "https://sso.example.com", Audiences: []string{"aud"}},
 						},
 						{
-							Issuer: auth.IssuerConfig{URL: "https://sso.example.com"},
+							Issuer: auth.IssuerConfig{URL: "https://sso.example.com", Audiences: []string{"aud"}},
 						},
 					},
 				}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -3,8 +3,8 @@ package auth
 import (
 	"context"
 	"crypto/rand"
-	"encoding/binary"
 	"errors"
+	"math/big"
 	"net/http"
 	"strings"
 	"time"
@@ -174,11 +174,9 @@ func observeAuthDuration(hist *prometheus.HistogramVec, start time.Time, result 
 
 // cryptoRandIntn returns a cryptographically random int in [0, n).
 func cryptoRandIntn(n int) int {
-	var buf [8]byte
-	_, _ = rand.Read(buf[:])
-	v := int(binary.LittleEndian.Uint64(buf[:]))
-	if v < 0 {
-		v = -v
+	v, err := rand.Int(rand.Reader, big.NewInt(int64(n)))
+	if err != nil {
+		return 0
 	}
-	return v % n
+	return int(v.Int64())
 }

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -2,8 +2,9 @@ package auth
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/binary"
 	"errors"
-	"math/rand/v2"
 	"net/http"
 	"strings"
 	"time"
@@ -102,7 +103,7 @@ func MiddlewareWithConfig(cfg MiddlewareConfig) func(http.Handler) http.Handler 
 			// Derive deadline from token expiry so streaming handlers terminate
 			// before the token becomes invalid. Jitter prevents timing oracle.
 			if !identity.ExpiresAt.IsZero() {
-				jitter := time.Duration(25+rand.IntN(10)) * time.Second
+				jitter := time.Duration(25+cryptoRandIntn(10)) * time.Second
 				deadline := identity.ExpiresAt.Add(-jitter)
 				var cancel context.CancelFunc
 				ctx, cancel = context.WithDeadline(ctx, deadline)
@@ -169,4 +170,15 @@ func observeAuthDuration(hist *prometheus.HistogramVec, start time.Time, result 
 	if hist != nil {
 		hist.WithLabelValues(result).Observe(time.Since(start).Seconds())
 	}
+}
+
+// cryptoRandIntn returns a cryptographically random int in [0, n).
+func cryptoRandIntn(n int) int {
+	var buf [8]byte
+	_, _ = rand.Read(buf[:])
+	v := int(binary.LittleEndian.Uint64(buf[:]))
+	if v < 0 {
+		v = -v
+	}
+	return v % n
 }

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"errors"
+	"math/rand/v2"
 	"net/http"
 	"strings"
 	"time"
@@ -97,6 +98,17 @@ func MiddlewareWithConfig(cfg MiddlewareConfig) func(http.Handler) http.Handler 
 
 			ctx = WithUserIdentity(ctx, identity)
 			ctx = logging.WithUserID(ctx, identity.Username)
+
+			// Derive deadline from token expiry so streaming handlers terminate
+			// before the token becomes invalid. Jitter prevents timing oracle.
+			if !identity.ExpiresAt.IsZero() {
+				jitter := time.Duration(25+rand.IntN(10)) * time.Second
+				deadline := identity.ExpiresAt.Add(-jitter)
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithDeadline(ctx, deadline)
+				defer cancel()
+			}
+
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
@@ -134,6 +146,8 @@ func classifyAuthError(err error) string {
 	switch {
 	case errors.Is(err, ErrTokenExpired):
 		return "token_expired"
+	case errors.Is(err, ErrNotYetValid):
+		return "not_yet_valid"
 	case errors.Is(err, ErrInvalidAudience):
 		return "invalid_audience"
 	case errors.Is(err, ErrUnknownIssuer):

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -11,6 +11,7 @@ func TestClassifyAuthError(t *testing.T) {
 		expected string
 	}{
 		{"expired", ErrTokenExpired, "token_expired"},
+		{"not yet valid", ErrNotYetValid, "not_yet_valid"},
 		{"audience", ErrInvalidAudience, "invalid_audience"},
 		{"unknown issuer", ErrUnknownIssuer, "unknown_issuer"},
 		{"malformed", ErrMalformedToken, "malformed_token"},

--- a/internal/auth/types.go
+++ b/internal/auth/types.go
@@ -1,13 +1,17 @@
 package auth
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // UserIdentity represents an authenticated user's identity extracted from a JWT.
 type UserIdentity struct {
-	Username string   `json:"username"`
-	Groups   []string `json:"groups,omitempty"`
-	Issuer   string   `json:"issuer"`
-	RawToken string   `json:"-"`
+	Username  string    `json:"username"`
+	Groups    []string  `json:"groups,omitempty"`
+	Issuer    string    `json:"issuer"`
+	RawToken  string    `json:"-"`
+	ExpiresAt time.Time `json:"expiresAt,omitempty"`
 }
 
 // String returns a safe representation that redacts the raw token (SEC-3).

--- a/internal/auth/validator_coverage_test.go
+++ b/internal/auth/validator_coverage_test.go
@@ -1,0 +1,222 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func testSignToken(t *testing.T, key *rsa.PrivateKey, kid string, claims interface{}) string {
+	t.Helper()
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: key},
+		(&jose.SignerOptions{}).WithHeader(jose.HeaderKey("kid"), kid),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := josejwt.Signed(signer).Claims(claims).Serialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func TestReady_NilCache(t *testing.T) {
+	// Business outcome: validator with no providers (no JWKS cache) is always ready
+	v := &JWTValidator{}
+	if !v.Ready() {
+		t.Error("Ready() should return true when no JWKS cache is configured")
+	}
+}
+
+func TestReady_HealthyCacheClosed(t *testing.T) {
+	// Business outcome: when all circuit breakers are closed, the service is ready
+	cache := NewJWKSCache(&http.Client{}, []string{"http://example.com/jwks"})
+	v := &JWTValidator{cache: cache}
+	if !v.Ready() {
+		t.Error("Ready() should return true when all breakers are closed")
+	}
+}
+
+func TestReady_UnhealthyCacheOpen(t *testing.T) {
+	// Business outcome: when a circuit breaker is open, the service reports not ready
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cache := NewJWKSCache(&http.Client{}, []string{srv.URL}, WithCBTimeout(50*time.Millisecond))
+	ctx := context.Background()
+
+	// Trip the circuit breaker: 3 consecutive failures
+	for i := 0; i < 4; i++ {
+		_, _ = cache.GetKeys(ctx, srv.URL)
+	}
+
+	v := &JWTValidator{cache: cache}
+	if v.Ready() {
+		t.Error("Ready() should return false when a breaker is open")
+	}
+}
+
+func TestWithCBMetrics_GaugeUpdatesOnStateChange(t *testing.T) {
+	// Business outcome: the CB state gauge reflects breaker state transitions
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	gauge := NewCircuitBreakerStateGauge()
+	keySet := testJWKS(t)
+	_ = keySet
+
+	cfg := Config{
+		JWT: []ProviderConfig{
+			{Issuer: IssuerConfig{URL: srv.URL, Audiences: []string{"aud"}}},
+		},
+	}
+
+	v, err := NewJWTValidator(cfg,
+		WithHTTPClient(srv.Client()),
+		WithCBMetrics(gauge),
+		WithCBTestTimeout(50*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("NewJWTValidator: %v", err)
+	}
+
+	// Generate a valid-looking token to trigger JWKS fetch
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	claims := map[string]interface{}{
+		"iss": srv.URL, "sub": "u", "aud": []string{"aud"},
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	token := testSignToken(t, key, "k1", claims)
+
+	// Trigger 4 validation attempts (JWKS fetches) to trip the CB
+	for i := 0; i < 4; i++ {
+		_, _ = v.Validate(context.Background(), token)
+	}
+
+	// Check that the gauge was set (state=2 means open)
+	var m dto.Metric
+	depLabel := "jwks_" + srv.URL
+	g, err := gauge.GetMetricWithLabelValues(depLabel)
+	if err != nil {
+		t.Fatalf("could not get metric: %v", err)
+	}
+	if err := g.Write(&m); err != nil {
+		t.Fatal(err)
+	}
+	if m.GetGauge().GetValue() != 2 {
+		t.Errorf("expected gauge=2 (open), got %v", m.GetGauge().GetValue())
+	}
+}
+
+func TestWithReplayCache_RejectsReplayedToken(t *testing.T) {
+	// Business outcome: a token used twice with the same jti is rejected the second time
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keySet := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{{Key: &key.PublicKey, KeyID: "k1", Algorithm: "RS256", Use: "sig"}},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(keySet)
+	}))
+	defer srv.Close()
+
+	rc := NewReplayCache(1 * time.Minute)
+	defer rc.Stop()
+
+	cfg := Config{
+		JWT: []ProviderConfig{
+			{Issuer: IssuerConfig{URL: srv.URL, Audiences: []string{"aud"}}},
+		},
+	}
+
+	v, err := NewJWTValidator(cfg, WithHTTPClient(&http.Client{}), WithReplayCache(rc))
+	if err != nil {
+		t.Fatalf("NewJWTValidator: %v", err)
+	}
+
+	claims := map[string]interface{}{
+		"iss": srv.URL, "sub": "alice", "aud": []string{"aud"},
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"jti": "unique-token-id-001",
+		"preferred_username": "alice",
+	}
+	token := testSignToken(t, key, "k1", claims)
+
+	// First use: should succeed
+	identity, err := v.Validate(context.Background(), token)
+	if err != nil {
+		t.Fatalf("first Validate failed: %v", err)
+	}
+	if identity.Username != "alice" {
+		t.Errorf("expected username alice, got %q", identity.Username)
+	}
+
+	// Replay: should be rejected
+	_, err = v.Validate(context.Background(), token)
+	if err == nil {
+		t.Fatal("expected error on replay, got nil")
+	}
+}
+
+func TestWithReplayCache_RequiresJTI(t *testing.T) {
+	// Business outcome: when replay protection is enabled, tokens without jti are rejected
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keySet := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{{Key: &key.PublicKey, KeyID: "k1", Algorithm: "RS256", Use: "sig"}},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(keySet)
+	}))
+	defer srv.Close()
+
+	rc := NewReplayCache(1 * time.Minute)
+	defer rc.Stop()
+
+	cfg := Config{
+		JWT: []ProviderConfig{
+			{Issuer: IssuerConfig{URL: srv.URL, Audiences: []string{"aud"}}},
+		},
+	}
+
+	v, err := NewJWTValidator(cfg, WithHTTPClient(&http.Client{}), WithReplayCache(rc))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Token without jti
+	claims := map[string]interface{}{
+		"iss": srv.URL, "sub": "alice", "aud": []string{"aud"},
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"preferred_username": "alice",
+	}
+	token := testSignToken(t, key, "k1", claims)
+
+	_, err = v.Validate(context.Background(), token)
+	if err == nil {
+		t.Fatal("expected error for missing jti with replay protection enabled")
+	}
+}

--- a/internal/auth/validator_coverage_test.go
+++ b/internal/auth/validator_coverage_test.go
@@ -155,8 +155,8 @@ func TestWithReplayCache_RejectsReplayedToken(t *testing.T) {
 
 	claims := map[string]interface{}{
 		"iss": srv.URL, "sub": "alice", "aud": []string{"aud"},
-		"exp": time.Now().Add(time.Hour).Unix(),
-		"jti": "unique-token-id-001",
+		"exp":                time.Now().Add(time.Hour).Unix(),
+		"jti":                "unique-token-id-001",
 		"preferred_username": "alice",
 	}
 	token := testSignToken(t, key, "k1", claims)
@@ -210,7 +210,7 @@ func TestWithReplayCache_RequiresJTI(t *testing.T) {
 	// Token without jti
 	claims := map[string]interface{}{
 		"iss": srv.URL, "sub": "alice", "aud": []string{"aud"},
-		"exp": time.Now().Add(time.Hour).Unix(),
+		"exp":                time.Now().Add(time.Hour).Unix(),
 		"preferred_username": "alice",
 	}
 	token := testSignToken(t, key, "k1", claims)

--- a/internal/ds/mock_client_test.go
+++ b/internal/ds/mock_client_test.go
@@ -1,0 +1,116 @@
+package ds
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jordigilh/kubernaut-apifrontend/internal/audit"
+)
+
+func TestMockClient_ListWorkflows(t *testing.T) {
+	expected := []Workflow{{ID: "wf-1", Name: "restart"}}
+	m := &MockClient{
+		ListWorkflowsFn: func(_ context.Context, _ ListWorkflowsOpts) ([]Workflow, error) {
+			return expected, nil
+		},
+	}
+	got, err := m.ListWorkflows(context.Background(), ListWorkflowsOpts{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "wf-1" {
+		t.Errorf("expected %v, got %v", expected, got)
+	}
+}
+
+func TestMockClient_GetRemediationHistory(t *testing.T) {
+	expected := []HistoricalRemediation{{ID: "r-1", Phase: "Completed"}}
+	m := &MockClient{
+		GetRemediationHistoryFn: func(_ context.Context, _ HistoryOpts) ([]HistoricalRemediation, error) {
+			return expected, nil
+		},
+	}
+	got, err := m.GetRemediationHistory(context.Background(), HistoryOpts{Namespace: "default"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "r-1" {
+		t.Errorf("expected %v, got %v", expected, got)
+	}
+}
+
+func TestMockClient_GetEffectiveness(t *testing.T) {
+	expected := &EffectivenessReport{SuccessRate: 0.95, SampleSize: 20}
+	m := &MockClient{
+		GetEffectivenessFn: func(_ context.Context, _ EffectivenessOpts) (*EffectivenessReport, error) {
+			return expected, nil
+		},
+	}
+	got, err := m.GetEffectiveness(context.Background(), EffectivenessOpts{WorkflowID: "wf-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.SuccessRate != 0.95 {
+		t.Errorf("expected 0.95, got %v", got.SuccessRate)
+	}
+}
+
+func TestMockClient_GetAuditTrail(t *testing.T) {
+	expected := []AuditEvent{{EventType: "tool_invoked", Actor: "alice"}}
+	m := &MockClient{
+		GetAuditTrailFn: func(_ context.Context, _ AuditTrailOpts) ([]AuditEvent, error) {
+			return expected, nil
+		},
+	}
+	got, err := m.GetAuditTrail(context.Background(), AuditTrailOpts{RRID: "rr-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Actor != "alice" {
+		t.Errorf("expected %v, got %v", expected, got)
+	}
+}
+
+func TestMockClient_WriteAuditEvents_DelegatesToFn(t *testing.T) {
+	var called bool
+	m := &MockClient{
+		WriteAuditEventsFn: func(_ context.Context, events []*audit.Event) error {
+			called = true
+			if len(events) != 1 {
+				t.Errorf("expected 1 event, got %d", len(events))
+			}
+			return nil
+		},
+	}
+	err := m.WriteAuditEvents(context.Background(), []*audit.Event{{Type: "test"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("WriteAuditEventsFn was not called")
+	}
+}
+
+func TestMockClient_WriteAuditEvents_NilFnReturnsNil(t *testing.T) {
+	// Business outcome: when WriteAuditEventsFn is nil, writes are silently discarded
+	m := &MockClient{}
+	err := m.WriteAuditEvents(context.Background(), []*audit.Event{{Type: "test"}})
+	if err != nil {
+		t.Fatalf("expected nil error when WriteAuditEventsFn is nil, got %v", err)
+	}
+}
+
+func TestMockClient_ErrorPropagation(t *testing.T) {
+	// Business outcome: errors from the mock are properly propagated to callers
+	expectedErr := errors.New("connection refused")
+	m := &MockClient{
+		ListWorkflowsFn: func(_ context.Context, _ ListWorkflowsOpts) ([]Workflow, error) {
+			return nil, expectedErr
+		},
+	}
+	_, err := m.ListWorkflows(context.Background(), ListWorkflowsOpts{})
+	if !errors.Is(err, expectedErr) {
+		t.Errorf("expected %v, got %v", expectedErr, err)
+	}
+}

--- a/internal/handler/mcp_bridge.go
+++ b/internal/handler/mcp_bridge.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jordigilh/kubernaut-apifrontend/internal/auth"
 	"github.com/jordigilh/kubernaut-apifrontend/internal/ds"
 	"github.com/jordigilh/kubernaut-apifrontend/internal/ka"
+	"github.com/jordigilh/kubernaut-apifrontend/internal/ratelimit"
 	"github.com/jordigilh/kubernaut-apifrontend/internal/security"
 	"github.com/jordigilh/kubernaut-apifrontend/internal/severity"
 	"github.com/jordigilh/kubernaut-apifrontend/internal/tools"
@@ -38,6 +39,7 @@ type MCPBridgeConfig struct {
 	Metrics            *MCPBridgeMetrics
 	ToolTimeout        time.Duration
 	MaxConcurrentTools int64
+	UserLimiter        *ratelimit.UserLimiter
 }
 
 // MCPBridgeMetrics holds Prometheus collectors specific to MCP bridge operations.
@@ -297,6 +299,22 @@ func wrapTool[In any](cfg *MCPBridgeConfig, sem *semaphore.Weighted, toolName st
 				Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}},
 				IsError: true,
 			}, nil, nil
+		}
+
+		// Per-user tool call rate limiting
+		if cfg.UserLimiter != nil {
+			username := usernameFromCtx(ctx)
+			if !cfg.UserLimiter.AllowToolCall(username) {
+				resultLabel = "rate_limited"
+				recordMetrics(cfg, toolName, resultLabel, start)
+				emitAudit(ctx, cfg, toolName, audit.EventMCPToolFailed, map[string]string{"error": "rate_limited"})
+				cfg.Logger.Info("tool call rate limited",
+					"tool", toolName, "user", username)
+				return &mcp.CallToolResult{
+					Content: []mcp.Content{&mcp.TextContent{Text: "rate limit exceeded — too many tool calls per minute, please retry later"}},
+					IsError: true,
+				}, nil, nil
+			}
 		}
 
 		// Timeout enforcement — covers semaphore wait + tool execution

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -117,6 +117,8 @@ func writeDeadlineMiddleware(next http.Handler) http.Handler {
 
 // trackSSEConnection registers active streaming connections with the tracker
 // for graceful shutdown. Each connection is tracked from start to completion.
+// It also clears the write deadline set by writeDeadlineMiddleware, since
+// streaming connections are long-lived and should not be killed by a fixed timeout.
 func trackSSEConnection(tracker *streaming.ConnectionTracker, next http.Handler) http.Handler {
 	if tracker == nil {
 		return next
@@ -137,6 +139,12 @@ func trackSSEConnection(tracker *streaming.ConnectionTracker, next http.Handler)
 			return
 		}
 		defer tracker.Remove(connID)
+
+		// Clear the write deadline for streaming — these are long-lived
+		// connections whose lifetime is managed by token expiry and graceful shutdown.
+		rc := http.NewResponseController(w)
+		_ = rc.SetWriteDeadline(time.Time{})
+
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/internal/resilience/k8s_dynamic_test.go
+++ b/internal/resilience/k8s_dynamic_test.go
@@ -395,6 +395,7 @@ func TestResilientResourceInterface_AllOperations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Delete() error = %v", err)
 	}
+
 }
 
 // IT-AF-038-087: All operations fail fast when CB is open
@@ -436,6 +437,12 @@ func TestResilientDynamicClient_AllOpsFailWhenCBOpen(t *testing.T) {
 	if _, err := res.Patch(ctx, "x", types.MergePatchType, []byte(`{}`), metav1.PatchOptions{}); !errors.Is(err, gobreaker.ErrOpenState) {
 		t.Errorf("cluster Patch: got %v, want ErrOpenState", err)
 	}
+	if _, err := res.Apply(ctx, "x", obj, metav1.ApplyOptions{FieldManager: "test"}); !errors.Is(err, gobreaker.ErrOpenState) {
+		t.Errorf("cluster Apply: got %v, want ErrOpenState", err)
+	}
+	if _, err := res.ApplyStatus(ctx, "x", obj, metav1.ApplyOptions{FieldManager: "test"}); !errors.Is(err, gobreaker.ErrOpenState) {
+		t.Errorf("cluster ApplyStatus: got %v, want ErrOpenState", err)
+	}
 
 	// Namespaced
 	ns := resilientClient.Resource(testGVR).Namespace("ns")
@@ -453,5 +460,11 @@ func TestResilientDynamicClient_AllOpsFailWhenCBOpen(t *testing.T) {
 	}
 	if _, err := ns.Patch(ctx, "x", types.MergePatchType, []byte(`{}`), metav1.PatchOptions{}); !errors.Is(err, gobreaker.ErrOpenState) {
 		t.Errorf("ns Patch: got %v, want ErrOpenState", err)
+	}
+	if _, err := ns.Apply(ctx, "x", obj, metav1.ApplyOptions{FieldManager: "test"}); !errors.Is(err, gobreaker.ErrOpenState) {
+		t.Errorf("ns Apply: got %v, want ErrOpenState", err)
+	}
+	if _, err := ns.ApplyStatus(ctx, "x", obj, metav1.ApplyOptions{FieldManager: "test"}); !errors.Is(err, gobreaker.ErrOpenState) {
+		t.Errorf("ns ApplyStatus: got %v, want ErrOpenState", err)
 	}
 }

--- a/internal/severity/llm.go
+++ b/internal/severity/llm.go
@@ -11,24 +11,46 @@ import (
 	prom "github.com/jordigilh/kubernaut-apifrontend/internal/prometheus"
 )
 
+// ContentGenerator abstracts the LLM content generation call for testability.
+type ContentGenerator interface {
+	GenerateContent(ctx context.Context, model string, contents []*genai.Content, config *genai.GenerateContentConfig) (*genai.GenerateContentResponse, error)
+}
+
+// genaiModels adapts genai.Models to the ContentGenerator interface.
+type genaiModels struct {
+	models genai.Models
+}
+
+func (g *genaiModels) GenerateContent(ctx context.Context, model string, contents []*genai.Content, config *genai.GenerateContentConfig) (*genai.GenerateContentResponse, error) {
+	return g.models.GenerateContent(ctx, model, contents, config)
+}
+
 // GenAITriager implements LLMTriager using Google GenAI (Vertex AI).
 type GenAITriager struct {
-	client *genai.Client
-	model  string
-	logger logr.Logger
+	generator ContentGenerator
+	model     string
+	logger    logr.Logger
 }
 
 // GenAITriagerConfig holds construction parameters for GenAITriager.
 type GenAITriagerConfig struct {
-	Client *genai.Client
-	Model  string
-	Logger logr.Logger
+	Client    *genai.Client
+	Generator ContentGenerator
+	Model     string
+	Logger    logr.Logger
 }
 
 // NewGenAITriager creates a production LLMTriager backed by Google GenAI.
+// If Generator is set, it is used directly; otherwise Client.Models is wrapped.
 func NewGenAITriager(cfg GenAITriagerConfig) *GenAITriager {
-	if cfg.Client == nil {
-		panic("NewGenAITriager: Client must not be nil")
+	var gen ContentGenerator
+	if cfg.Generator != nil {
+		gen = cfg.Generator
+	} else {
+		if cfg.Client == nil {
+			panic("NewGenAITriager: Client or Generator must not be nil")
+		}
+		gen = &genaiModels{models: *cfg.Client.Models}
 	}
 	if cfg.Model == "" {
 		cfg.Model = "gemini-2.0-flash"
@@ -37,9 +59,9 @@ func NewGenAITriager(cfg GenAITriagerConfig) *GenAITriager {
 		cfg.Logger = logr.Discard()
 	}
 	return &GenAITriager{
-		client: cfg.Client,
-		model:  cfg.Model,
-		logger: cfg.Logger,
+		generator: gen,
+		model:     cfg.Model,
+		logger:    cfg.Logger,
 	}
 }
 
@@ -56,7 +78,7 @@ func (g *GenAITriager) TriagePure(ctx context.Context, input TriageInput) (Triag
 }
 
 func (g *GenAITriager) classify(ctx context.Context, prompt string) (TriageResult, error) {
-	resp, err := g.client.Models.GenerateContent(ctx, g.model, genai.Text(prompt), nil)
+	resp, err := g.generator.GenerateContent(ctx, g.model, genai.Text(prompt), nil)
 	if err != nil {
 		return TriageResult{}, fmt.Errorf("LLM call failed: %w", err)
 	}

--- a/internal/severity/llm.go
+++ b/internal/severity/llm.go
@@ -21,6 +21,7 @@ type genaiModels struct {
 	models genai.Models
 }
 
+// GenerateContent delegates to the underlying genai.Models client.
 func (g *genaiModels) GenerateContent(ctx context.Context, model string, contents []*genai.Content, config *genai.GenerateContentConfig) (*genai.GenerateContentResponse, error) {
 	return g.models.GenerateContent(ctx, model, contents, config)
 }

--- a/internal/severity/llm_integration_test.go
+++ b/internal/severity/llm_integration_test.go
@@ -1,0 +1,61 @@
+//go:build llm_integration
+
+package severity
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"google.golang.org/genai"
+)
+
+func TestLLMIntegration_RealClassification(t *testing.T) {
+	project := os.Getenv("LLM_PROJECT")
+	if project == "" {
+		t.Skip("LLM_PROJECT not set — skipping integration test")
+	}
+	region := os.Getenv("LLM_REGION")
+	if region == "" {
+		region = "us-central1"
+	}
+	model := os.Getenv("LLM_MODEL")
+	if model == "" {
+		model = "gemini-2.0-flash"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, err := genai.NewClient(ctx, &genai.ClientConfig{
+		Project:  project,
+		Location: region,
+	})
+	if err != nil {
+		t.Fatalf("genai.NewClient: %v", err)
+	}
+
+	triager := NewGenAITriager(GenAITriagerConfig{Client: client, Model: model})
+
+	input := TriageInput{
+		Namespace:   "production",
+		Kind:        "Pod",
+		Name:        "web-frontend-abc123",
+		Description: "CrashLoopBackOff: container exits with OOMKilled status every 30 seconds",
+	}
+
+	result, err := triager.TriagePure(ctx, input)
+	if err != nil {
+		t.Fatalf("TriagePure: %v", err)
+	}
+
+	validSeverities := map[string]bool{"critical": true, "high": true, "medium": true, "low": true}
+	if !validSeverities[result.Severity] {
+		t.Errorf("unexpected severity %q (not in valid set)", result.Severity)
+	}
+	if result.Confidence <= 0 || result.Confidence > 1.0 {
+		t.Errorf("confidence %v out of [0,1] range", result.Confidence)
+	}
+	t.Logf("LLM classified as %q with confidence %.2f", result.Severity, result.Confidence)
+}

--- a/internal/severity/llm_triager_test.go
+++ b/internal/severity/llm_triager_test.go
@@ -1,0 +1,120 @@
+package severity
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/genai"
+)
+
+type mockGenerator struct {
+	resp *genai.GenerateContentResponse
+	err  error
+}
+
+func (m *mockGenerator) GenerateContent(_ context.Context, _ string, _ []*genai.Content, _ *genai.GenerateContentConfig) (*genai.GenerateContentResponse, error) {
+	return m.resp, m.err
+}
+
+func TestGenAITriager_ClassifyHappyPath(t *testing.T) {
+	// Business outcome: when LLM returns a valid severity, it's normalized and returned with full confidence
+	gen := &mockGenerator{
+		resp: &genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{
+				{Content: &genai.Content{Parts: []*genai.Part{{Text: "critical"}}}},
+			},
+		},
+	}
+	triager := NewGenAITriager(GenAITriagerConfig{Generator: gen, Model: "test-model"})
+
+	result, err := triager.TriagePure(context.Background(), TriageInput{Description: "HighCPU"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Severity != "critical" {
+		t.Errorf("expected severity 'critical', got %q", result.Severity)
+	}
+	if result.Confidence != 1.0 {
+		t.Errorf("expected confidence 1.0, got %v", result.Confidence)
+	}
+}
+
+func TestGenAITriager_ClassifyErrorPath(t *testing.T) {
+	// Business outcome: when LLM call fails, error is propagated
+	gen := &mockGenerator{err: errors.New("network timeout")}
+	triager := NewGenAITriager(GenAITriagerConfig{Generator: gen, Model: "test-model"})
+
+	_, err := triager.TriagePure(context.Background(), TriageInput{Description: "HighCPU"})
+	if err == nil {
+		t.Fatal("expected error from failed LLM call")
+	}
+}
+
+func TestGenAITriager_ClassifyNilResponse(t *testing.T) {
+	// Business outcome: nil response is treated as an error
+	gen := &mockGenerator{resp: nil}
+	triager := NewGenAITriager(GenAITriagerConfig{Generator: gen, Model: "test-model"})
+
+	_, err := triager.TriagePure(context.Background(), TriageInput{Description: "HighCPU"})
+	if err == nil {
+		t.Fatal("expected error for nil response")
+	}
+}
+
+func TestGenAITriager_ClassifyEmptyResponse(t *testing.T) {
+	// Business outcome: response with no text parts is treated as error
+	gen := &mockGenerator{
+		resp: &genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{
+				{Content: &genai.Content{Parts: []*genai.Part{}}},
+			},
+		},
+	}
+	triager := NewGenAITriager(GenAITriagerConfig{Generator: gen, Model: "test-model"})
+
+	_, err := triager.TriagePure(context.Background(), TriageInput{Description: "HighCPU"})
+	if err == nil {
+		t.Fatal("expected error for empty response")
+	}
+}
+
+func TestGenAITriager_ClassifyMalformedText(t *testing.T) {
+	// Business outcome: unrecognized severity text gets normalized and marked low confidence
+	gen := &mockGenerator{
+		resp: &genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{
+				{Content: &genai.Content{Parts: []*genai.Part{{Text: "urgent!!!"}}}},
+			},
+		},
+	}
+	triager := NewGenAITriager(GenAITriagerConfig{Generator: gen, Model: "test-model"})
+
+	result, err := triager.TriagePure(context.Background(), TriageInput{Description: "HighCPU"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Confidence >= 1.0 {
+		t.Errorf("expected low confidence for unrecognized severity, got %v", result.Confidence)
+	}
+}
+
+func TestGenAITriager_TriageWithRules(t *testing.T) {
+	// Business outcome: rule context is included in prompt and classification works
+	gen := &mockGenerator{
+		resp: &genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{
+				{Content: &genai.Content{Parts: []*genai.Part{{Text: "high"}}}},
+			},
+		},
+	}
+	triager := NewGenAITriager(GenAITriagerConfig{Generator: gen, Model: "test-model"})
+
+	result, err := triager.TriageWithRules(context.Background(), nil, TriageInput{Description: "HighCPU"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Severity != "high" {
+		t.Errorf("expected severity 'high', got %q", result.Severity)
+	}
+}

--- a/internal/tlswiring/tlswiring_test.go
+++ b/internal/tlswiring/tlswiring_test.go
@@ -8,6 +8,8 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
+	"io"
 	"math/big"
 	"net"
 	"net/http"
@@ -280,6 +282,56 @@ func TestCAReloadableTransport_NonExistentFile(t *testing.T) {
 	_, _, err := tlswiring.CAReloadableTransport("/nonexistent/ca.crt", testLogger())
 	if err == nil {
 		t.Fatal("expected error with non-existent file")
+	}
+}
+
+func TestCAReloadableTransport_RoundTrip(t *testing.T) {
+	// Business outcome: an HTTP request goes through the CAReloadableTransport
+	// and reaches the target TLS server using the loaded CA certificate.
+	t.Parallel()
+	certDir := generateTestCerts(t)
+	caFile := filepath.Join(certDir, "tls.crt")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ping", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, "pong")
+	})
+
+	srv := &http.Server{Handler: mux}
+	enabled, _, err := tlswiring.ConfigureServer(srv, certDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !enabled {
+		t.Fatal("expected TLS enabled")
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsLn := tls.NewListener(ln, srv.TLSConfig)
+	defer func() { _ = srv.Close() }()
+	go func() { _ = srv.Serve(tlsLn) }()
+
+	rt, watcher, err := tlswiring.CAReloadableTransport(caFile, testLogger())
+	if err != nil {
+		t.Fatalf("CAReloadableTransport: %v", err)
+	}
+	if watcher == nil {
+		t.Fatal("expected non-nil watcher")
+	}
+
+	client := &http.Client{Transport: rt, Timeout: 5 * time.Second}
+	resp, err := client.Get(fmt.Sprintf("https://%s/ping", ln.Addr().String()))
+	if err != nil {
+		t.Fatalf("GET through CAReloadableTransport failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "pong" {
+		t.Fatalf("expected 'pong', got %q", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements the full RC1 test hardening plan (7 logical commits):

**Security hardening (production code):**
- PS-2: Enforce `nbf` (not-before) JWT claim — reject tokens not yet valid
- PS-1: JWKS cache refresh TTL — skip network fetch when keys are fresh (5min default), preventing amplification attacks
- PS-3: Strict `Config.Validate()` — reject empty issuer URLs, empty audiences, empty CEL expressions, malformed JWKS URLs at startup
- Token-expiry stream termination: context deadline derived from `exp` claim ensures streaming handlers terminate before token invalidity
- Delegation guard: outbound requests with expired tokens fail-closed

**Operational and supply-chain:**
- OP-1: Fix PrometheusRule alert label (`status="401"` not `code="401"`)
- SC-1: Add `go mod verify` step in CI
- SC-2: Pin Syft to v1.20.0 in release workflow
- PERF-2: Clear write deadline for SSE/streaming connections
- PERF-1: Wire `UserLimiter.AllowToolCall` into MCP tool dispatch path

**Test coverage:**
- Auth: `Ready()`, `WithCBMetrics()`, `WithReplayCache()` integration tests
- DS: Full `MockClient` method coverage with error propagation
- Resilience: `Apply`/`ApplyStatus` CB protection (fail-fast when open)
- TLS: `CAReloadableTransport.RoundTrip` integration test with real TLS server
- Severity: `ContentGenerator` interface extraction + mock-based triager tests
- LLM: Build-tagged integration test + `make test-llm-local` target + `.gitignore` safeguards
- Adversarial OIDC: 18 attack vectors (crypto, claim manipulation, protocol, replay)

**Approach:** TDD throughout — tests verify business outcomes, not implementation details.

## Test plan

- [x] All unit tests pass locally (`go test ./... -count=1` excluding E2E)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [ ] CI passes (lint, security, unit tests, E2E)
- [ ] Verify `go mod verify` step runs in CI
- [ ] Verify adversarial tests all pass in CI


Made with [Cursor](https://cursor.com)