### PR TITLE
fix: do not cache empty Prometheus rule groups in triage pipeline

### DIFF
--- a/internal/severity/triage.go
+++ b/internal/severity/triage.go
@@ -315,7 +315,9 @@ func (t *Triager) fetchRules(ctx context.Context) ([]prom.RuleGroup, error) {
 	if err != nil {
 		return nil, err
 	}
-	t.cache.Set(groups)
+	if len(groups) > 0 {
+		t.cache.Set(groups)
+	}
 	return groups, nil
 }
 

--- a/internal/severity/triage_test.go
+++ b/internal/severity/triage_test.go
@@ -645,6 +645,97 @@ var _ = Describe("Triage Orchestrator", func() {
 			Expect(testutil.CollectAndCount(duration)).To(BeNumerically(">", 0))
 		})
 	})
+
+	Describe("Rules Cache Behavior", func() {
+		It("UT-AF-T-043: empty GetRules result is not cached, subsequent call retries", func() {
+			callCount := 0
+			var mu sync.Mutex
+
+			getRulesFunc := func() ([]prom.RuleGroup, error) {
+				mu.Lock()
+				defer mu.Unlock()
+				callCount++
+				if callCount == 1 {
+					return []prom.RuleGroup{}, nil
+				}
+				return []prom.RuleGroup{{
+					Name: "test",
+					Rules: []prom.Rule{
+						{Name: "NetworkLatency", Query: `latency{namespace="prod"}`, State: "inactive", Labels: map[string]string{"severity": "high"}},
+					},
+				}}, nil
+			}
+
+			countingProm := &callCountingPromClient{
+				base:         &mockPromClient{alerts: []prom.Alert{}},
+				getRulesFunc: getRulesFunc,
+			}
+
+			cfg := defaultCfg
+			cfg.CacheTTLSeconds = 30
+			llm := &mockLLM{
+				pureResult: severity.TriageResult{Severity: "medium"},
+				ruleResult: severity.TriageResult{Severity: "high"},
+			}
+			triager := severity.NewTriager(countingProm, llm, cfg, logr.Discard())
+
+			// First triage: empty rules → falls to Tier 3 (LLM pure)
+			result, err := triager.Triage(context.Background(), defaultInput)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Source).To(Equal(severity.SourceLLMTriage))
+
+			// Second triage (same triager, same cache): should re-fetch rules
+			// because empty results are not cached
+			result2, err := triager.Triage(context.Background(), defaultInput)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result2.Source).To(Equal(severity.SourceLLMRuleInform))
+
+			mu.Lock()
+			Expect(callCount).To(Equal(2), "GetRules should be called twice — empty result must not be cached")
+			mu.Unlock()
+		})
+
+		It("UT-AF-T-044: non-empty GetRules result IS cached within TTL", func() {
+			callCount := 0
+			var mu sync.Mutex
+
+			getRulesFunc := func() ([]prom.RuleGroup, error) {
+				mu.Lock()
+				defer mu.Unlock()
+				callCount++
+				return []prom.RuleGroup{{
+					Name: "test",
+					Rules: []prom.Rule{
+						{Name: "NetworkLatency", Query: `latency{namespace="prod"}`, State: "inactive", Labels: map[string]string{"severity": "high"}},
+					},
+				}}, nil
+			}
+
+			countingProm := &callCountingPromClient{
+				base:         &mockPromClient{alerts: []prom.Alert{}},
+				getRulesFunc: getRulesFunc,
+			}
+
+			cfg := defaultCfg
+			cfg.CacheTTLSeconds = 30
+			llm := &mockLLM{ruleResult: severity.TriageResult{Severity: "high"}}
+			triager := severity.NewTriager(countingProm, llm, cfg, logr.Discard())
+
+			// First triage: gets rules → Tier 2.5
+			result, err := triager.Triage(context.Background(), defaultInput)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Source).To(Equal(severity.SourceLLMRuleInform))
+
+			// Second triage: should use cache, NOT call GetRules again
+			result2, err := triager.Triage(context.Background(), defaultInput)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result2.Source).To(Equal(severity.SourceLLMRuleInform))
+
+			mu.Lock()
+			Expect(callCount).To(Equal(1), "GetRules should be called only once — result was cached")
+			mu.Unlock()
+		})
+	})
 })
 
 // --- Test mocks ---
@@ -701,4 +792,21 @@ func (m *mockLLM) TriageWithRules(_ context.Context, _ []prom.Rule, _ severity.T
 func (m *mockLLM) TriagePure(_ context.Context, _ severity.TriageInput) (severity.TriageResult, error) {
 	m.pureCalled = true
 	return m.pureResult, m.pureErr
+}
+
+type callCountingPromClient struct {
+	base         *mockPromClient
+	getRulesFunc func() ([]prom.RuleGroup, error)
+}
+
+func (c *callCountingPromClient) GetAlerts(ctx context.Context) ([]prom.Alert, error) {
+	return c.base.GetAlerts(ctx)
+}
+
+func (c *callCountingPromClient) GetRules(_ context.Context) ([]prom.RuleGroup, error) {
+	return c.getRulesFunc()
+}
+
+func (c *callCountingPromClient) InstantQuery(ctx context.Context, query string) (*prom.QueryResult, error) {
+	return c.base.InstantQuery(ctx, query)
 }

--- a/test/e2e/severity_triage_test.go
+++ b/test/e2e/severity_triage_test.go
@@ -160,10 +160,10 @@ var _ = Describe("Severity Triage Pipeline (G12)", Ordered, ContinueOnFailure, L
 		Expect(err).NotTo(HaveOccurred(), text)
 		// HighMemory rule targets test-pending-target but is inactive (no metric
 		// injected, so for:1h never starts). Depending on rule evaluation timing,
-		// triage may return pending_alert, llm_rule_informed (Tier 2.5), or
-		// llm_triage if GetRules returns empty due to Prometheus rule load timing.
+		// triage may return pending_alert (if Prometheus just started evaluating)
+		// or llm_rule_informed (Tier 2.5 — inactive rule matched, LLM fallback).
 		src := parseJSONStringField(text, "severity_source")
-		Expect(src).To(BeElementOf("pending_alert", "firing_alert", "llm_rule_informed", "llm_triage"),
+		Expect(src).To(BeElementOf("pending_alert", "firing_alert", "llm_rule_informed"),
 			"expected Prometheus-informed source, got: %s (full: %s)", src, text)
 	})
 
@@ -185,7 +185,7 @@ var _ = Describe("Severity Triage Pipeline (G12)", Ordered, ContinueOnFailure, L
 		text, toolErr := mcpToolCall("af_create_rr", createRRArgs("sev-tier2-ns", "test-inactive-target", nil))
 		Expect(toolErr).NotTo(HaveOccurred(), text)
 		src := parseJSONStringField(text, "severity_source")
-		Expect(src).To(BeElementOf("rule_evaluation", "llm_rule_informed", "llm_triage"),
+		Expect(src).To(BeElementOf("rule_evaluation", "llm_rule_informed"),
 			"expected Tier 2 or Tier 2.5 source, got: %s (full: %s)", src, text)
 	})
 
@@ -193,11 +193,7 @@ var _ = Describe("Severity Triage Pipeline (G12)", Ordered, ContinueOnFailure, L
 		skipIfNoAlerts()
 		text, err := mcpToolCall("af_create_rr", createRRArgs("no-data-ns", "test-nodata-target", nil))
 		Expect(err).NotTo(HaveOccurred(), text)
-		// When GetRules returns empty (Prometheus rule load timing), pipeline
-		// falls through to Tier 3 (llm_triage). Both are acceptable.
-		src := parseJSONStringField(text, "severity_source")
-		Expect(src).To(BeElementOf("llm_rule_informed", "llm_triage"),
-			"expected Tier 2.5 or Tier 3 source, got: %s (full: %s)", src, text)
+		expectSeveritySource(text, "llm_rule_informed")
 	})
 
 	It("TC-E2E-SEV-05: Tier 3 — No rules", func() {


### PR DESCRIPTION
## Summary

- **Root cause**: When Prometheus restarts or hasn't finished loading rules, `GetRules` returns an empty slice (no error). `fetchRules` was caching this empty result for the full cache TTL (30s), causing all triage calls during that window to skip Tier 1.5/2/2.5 and fall through to Tier 3 (pure LLM).
- **Fix**: Only cache `GetRules` results when `len(groups) > 0`. Empty results are not cached, so subsequent calls retry immediately.
- **Tests**: Added `UT-AF-T-043` (empty result not cached, next call retries) and `UT-AF-T-044` (non-empty result IS cached within TTL).
- **E2E**: Reverted the test loosening from `c1311b8` — SEV-02/03/04 expectations are strict again.

## Test plan

- [x] `UT-AF-T-043` verifies empty rules trigger a retry on next triage call
- [x] `UT-AF-T-044` verifies non-empty rules are cached within TTL (no regression)
- [x] Full severity suite passes with `-race`
- [x] E2E `severity_triage_test.go` compiles with strict expectations restored
- [ ] CI green (lint + E2E)


Made with [Cursor](https://cursor.com)